### PR TITLE
(maint) Add coveralls.io integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo add-apt-repository -y ppa:boost-latest/ppa
   - sudo apt-get update
-  # which is needed to install gcc 4.8
+  # which is needed to install gcc 4.8 (and gcov)
   - sudo apt-get -y install gcc-4.8
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+  - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 50
   # and g++ 4.8
   - sudo apt-get -y install g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
@@ -27,6 +28,7 @@ before_install:
   - pushd $HOME && tar xzf yaml-cpp-0.5.1.tgz && cd $HOME/yaml-cpp-0.5.1 && cmake -DBUILD_SHARED_LIBS=ON . && make > /dev/null && sudo make install > /dev/null && popd
   # Install libblkid-dev
   - sudo apt-get -y install libblkid-dev
+  - sudo pip install cpp-coveralls
 
 script: ./scripts/travis_target.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     else()
         set(FACTER_CXX_FLAGS "${FACTER_CXX_FLAGS} -Wno-deprecated")
     endif()
+
+    # Add Code Coverage
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(FACTER_CXX_FLAGS "${FACTER_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+    endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # maybe-uninitialized is a relatively new GCC warning that Boost 1.57 violates; disable it for now until it's available in Clang as well
     # it's also sometimes wrong
@@ -118,6 +123,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(FACTER_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-unknown-pragmas -Wno-missing-field-initializers")
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
         set(FACTER_CXX_FLAGS "${FACTER_CXX_FLAGS} -Wextra")
+    endif()
+
+    # Add Code Coverage
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(FACTER_CXX_FLAGS "${FACTER_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Native Facter
 =============
 
+[![Linux Build Status](https://travis-ci.org/puppetlabs/cfacter.svg?branch=master)](https://travis-ci.org/puppetlabs/cfacter)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/5kltn836jkic167w/branch/master?svg=true)](https://ci.appveyor.com/project/MikaelSmith/cfacter-735/branch/master)
+[![Unit Coverage Status](https://img.shields.io/coveralls/puppetlabs/cfacter.svg)](https://coveralls.io/r/puppetlabs/cfacter)
+
 An implementation of facter functionality in C++11, providing:
 
 * a shared library which gather facts about the system

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -24,7 +24,7 @@ function travis_make()
     if [ $1 == "cpplint" ]; then
         export MAKE_TARGET="cpplint"
     else
-        export MAKE_TARGET="all_unity"
+        export MAKE_TARGET="all"
     fi
     make $MAKE_TARGET
     if [ $? -ne 0 ]; then
@@ -40,10 +40,12 @@ function travis_make()
             exit 1
         fi
 
+        if [ $1 == "debug" ]; then
+            coveralls --gcov-options '\-lp' -r ..
+        fi
+
         # Install into the system for the gem
-        # Use install fast to avoid dependency checks that don't
-        # co-operate with the unity build.
-        sudo make install/fast
+        sudo make install
         if [ $? -ne 0 ]; then
             echo "install failed."
             exit 1


### PR DESCRIPTION
Add coveralls.io integration and CI status badges. Measures code coverage on unit test runs in Travis CI using gcov; unity builds on Travis are reverted to allow for code coverage reporting.