### PR TITLE
(CFACT-150) Update default external fact directory for unified agent layout

### DIFF
--- a/lib/src/facts/posix/collection.cc
+++ b/lib/src/facts/posix/collection.cc
@@ -25,8 +25,7 @@ namespace facter { namespace facts {
                 directories.emplace_back(home + "/.facter/facts.d");
             }
         } else {
-            directories.emplace_back("/etc/facter/facts.d");
-            directories.emplace_back("/etc/puppetlabs/facter/facts.d");
+            directories.emplace_back("/opt/puppetlabs/agent/facts.d");
         }
         return directories;
     }


### PR DESCRIPTION
This commit updates the default search directory for external facts.
We now look in `/opt/puppetlabs/agent/facts.d` for both open source and
PE versions of Facter. Note that this change only affects Unix agents,
as Windows paths are staying the same.

This change is part of the unified agent effort.