### PR TITLE
(maint) Use pre-compiled doxygen and yaml-cpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ before_install:
   - sudo tar xjvf pcre-8.36_install.tar.bz2 --strip 1 -C /usr/local
   - wget https://s3.amazonaws.com/kylo-pl-bucket/cppcheck-1.67_install.tar.bz2
   - sudo tar xjvf cppcheck-1.67_install.tar.bz2 --strip 1 -C /usr/local
-  # Install doxygen
-  - wget https://github.com/doxygen/doxygen/archive/Release_1_8_7.tar.gz -O $HOME/doxygen-1.8.7.tgz
-  - pushd $HOME && tar xzf doxygen-1.8.7.tgz && cd $HOME/doxygen-Release_1_8_7 && ./configure > /dev/null && make > /dev/null && sudo make install > /dev/null && popd
+  # grab a pre-built doxygen 1.8.7 from s3
+  - wget https://s3.amazonaws.com/kylo-pl-bucket/doxygen_install.tar.bz2
+  - sudo tar xjvf doxygen_install.tar.bz2 --strip 1 -C /usr/local
   # Install dependencies of cfacter
   - sudo apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev
-  - wget https://yaml-cpp.googlecode.com/files/yaml-cpp-0.5.1.tar.gz -O $HOME/yaml-cpp-0.5.1.tgz
-  - pushd $HOME && tar xzf yaml-cpp-0.5.1.tgz && cd $HOME/yaml-cpp-0.5.1 && cmake -DBUILD_SHARED_LIBS=ON . && make > /dev/null && sudo make install > /dev/null && popd
+  - wget https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1_install.tar.bz2
+  - sudo tar xjvf yaml-cpp-0.5.1_install.tar.bz2 --strip 1 -C /usr/local
   # Install libblkid-dev
   - sudo apt-get -y install libblkid-dev
   # Install coveralls.io update utility


### PR DESCRIPTION
Eliminate longest extraneous build steps from Travis CI.