### PR TITLE
(maint) Fixes for Coverity Scan issues

### DIFF
--- a/exe/cfacter.cc
+++ b/exe/cfacter.cc
@@ -107,11 +107,11 @@ int main(int argc, char **argv)
 {
     using namespace facter::logging;
 
-    // Fix args on Windows to be UTF-8
-    boost::nowide::args arg_utf8(argc, argv);
-
     try
     {
+        // Fix args on Windows to be UTF-8
+        boost::nowide::args arg_utf8(argc, argv);
+
         // Setup logging
         setup_logging(boost::nowide::cerr);
 
@@ -265,6 +265,8 @@ int main(int argc, char **argv)
         }
         facts.write(boost::nowide::cout, fmt, queries);
         boost::nowide::cout << endl;
+
+        return EXIT_SUCCESS;
     } catch (exception& ex) {
         LOG_FATAL("unhandled exception: %1%", ex.what());
         return EXIT_FAILURE;

--- a/lib/inc/facter/ruby/api.hpp
+++ b/lib/inc/facter/ruby/api.hpp
@@ -580,9 +580,9 @@ namespace facter {  namespace ruby {
         static int hash_for_each_thunk(VALUE key, VALUE value, VALUE arg);
 
         facter::util::dynamic_library _library;
-        VALUE _nil;
-        VALUE _true;
-        VALUE _false;
+        VALUE _nil = 0u;
+        VALUE _true = 0u;
+        VALUE _false = 0u;
         bool _initialized;
         bool _include_stack_trace;
     };

--- a/lib/inc/facter/ruby/api.hpp
+++ b/lib/inc/facter/ruby/api.hpp
@@ -583,8 +583,8 @@ namespace facter {  namespace ruby {
         VALUE _nil = 0u;
         VALUE _true = 0u;
         VALUE _false = 0u;
-        bool _initialized;
-        bool _include_stack_trace;
+        bool _initialized = false;
+        bool _include_stack_trace = false;
     };
 
 }}  // namespace facter::ruby

--- a/lib/src/facts/posix/uptime_resolver.cc
+++ b/lib/src/facts/posix/uptime_resolver.cc
@@ -16,19 +16,19 @@ namespace facter { namespace facts { namespace posix {
         int days, hours, minutes;
 
         if (re_search(output, "(\\d+) day(?:s|\\(s\\))?,?\\s+(\\d+):-?(\\d+)", &days, &hours, &minutes)) {
-            return 86400 * days + 3600 * hours + 60 * minutes;
+            return 86400ll * days + 3600ll * hours + 60ll * minutes;
         } else if (re_search(output, "(\\d+) day(?:s|\\(s\\))?,\\s+(\\d+) hr(?:s|\\(s\\))?,", &days, &hours)) {
-            return 86400 * days + 3600 * hours;
+            return 86400ll * days + 3600ll * hours;
         } else if (re_search(output, "(\\d+) day(?:s|\\(s\\))?,\\s+(\\d+) min(?:s|\\(s\\))?,", &days, &minutes)) {
-            return 86400 * days + 60 * minutes;
+            return 86400ll * days + 60ll * minutes;
         } else if (re_search(output, "(\\d+) day(?:s|\\(s\\))?,", &days)) {
-            return 86400 * days;
+            return 86400ll * days;
         } else if (re_search(output, "up\\s+(\\d+):-?(\\d+),", &hours, &minutes)) {
-            return 3600 * hours + 60 * minutes;
+            return 3600ll * hours + 60ll * minutes;
         } else if (re_search(output, "(\\d+) hr(?:s|\\(s\\))?,", &hours)) {
-            return 3600 * hours;
+            return 3600ll * hours;
         } else if (re_search(output, "(\\d+) min(?:s|\\(s\\))?,", &minutes)) {
-            return 60 * minutes;
+            return 60ll * minutes;
         }
         return -1;
     }

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -98,9 +98,7 @@ namespace facter { namespace ruby {
         LOAD_SYMBOL(ruby_init),
         LOAD_SYMBOL(ruby_options),
         LOAD_SYMBOL(ruby_cleanup),
-        _library(move(library)),
-        _initialized(false),
-        _include_stack_trace(false)
+        _library(move(library))
     {
     }
 

--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -1,6 +1,7 @@
 #include <gmock/gmock.h>
 #include <facter/ruby/api.hpp>
 #include <facter/logging/logging.hpp>
+#include <boost/nowide/iostream.hpp>
 
 using namespace std;
 using namespace facter::ruby;
@@ -8,18 +9,25 @@ using namespace facter::logging;
 
 int main(int argc, char **argv)
 {
-    // Disable logging for tests
-    set_level(log_level::none);
+    try
+    {
+        // Disable logging for tests
+        set_level(log_level::none);
 
-    // Uncomment this to get debug output during a test run
-    // setup_logging(cout);
-    // set_level(log_level::debug);
+        // Uncomment this to get debug output during a test run
+        // setup_logging(cout);
+        // set_level(log_level::debug);
 
-    // Before running tests, initialize Ruby
-    auto ruby = api::instance();
-    if (ruby) {
-        ruby->initialize();
+        // Before running tests, initialize Ruby
+        auto ruby = api::instance();
+        if (ruby) {
+            ruby->initialize();
+        }
+
+        ::testing::InitGoogleTest(&argc, argv);
+        return RUN_ALL_TESTS();
+    } catch (exception& ex) {
+        boost::nowide::cerr << "Failure running tests: " << ex.what() << endl;
+        return EXIT_FAILURE;
     }
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Catch all exceptions, initialize variables, and ensure no integer
truncation when returning size_t.