### PR TITLE
(maint) Fix cppcheck warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ else()
 endif()
 
 add_custom_target(cppcheck
-    COMMAND cppcheck --enable=performance --error-exitcode=2 --quiet "${PROJECT_SOURCE_DIR}/lib" "${PROJECT_SOURCE_DIR}/exe"
+    COMMAND cppcheck --enable=warning,performance --error-exitcode=2 --quiet "${PROJECT_SOURCE_DIR}/lib" "${PROJECT_SOURCE_DIR}/exe"
 )
 
 add_subdirectory(lib)

--- a/lib/src/execution/posix/execution.cc
+++ b/lib/src/execution/posix/execution.cc
@@ -115,9 +115,6 @@ namespace facter { namespace execution {
         // A non-zero child pid means we're running in the context of the parent process
         if (child)
         {
-            // Get a special logger used specifically for child process output
-            std::string logger = "|";
-
             // Close the unused descriptors
             stdin_read.release();
             stdout_write.release();
@@ -134,7 +131,7 @@ namespace facter { namespace execution {
                     // The call to read was interrupted by a signal before any data was read. Retry read.
                     // See http://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html
                     // This happens in Xcode's debugging.
-                    LOG_DEBUG("child pipe read was interrupted and will be retried: %1% (%2%).", strerror(errno), errno);
+                    LOG_DEBUG("child pipe read was interrupted and will be retried.");
                     errno = 0;
                     buffer.resize(0);
                     return true;

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -291,7 +291,7 @@ namespace facter { namespace execution {
             return { true, move(result) };
         } catch (child_exit_exception &e) {
             if (options[execution_options::throw_on_nonzero_exit]) {
-                throw e;
+                throw;
             } else {
                 LOG_DEBUG("%1% (%2%): %3%", e.what(), e.status_code(), system_error());
                 return { false, move(e.output()) };

--- a/lib/src/facts/external/json_resolver.cc
+++ b/lib/src/facts/external/json_resolver.cc
@@ -160,7 +160,7 @@ namespace facter { namespace facts { namespace external {
             }
         }
 
-        void check_initialized()
+        void check_initialized() const
         {
             if (!_initialized) {
                 throw external::external_fact_exception("expected document to contain an object.");

--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -192,7 +192,7 @@ namespace facter { namespace facts { namespace linux {
             }
             return true;
         });
-        return {};
+        return value;
     }
 
     string virtualization_resolver::get_xen_vm()

--- a/lib/src/facts/resolvers/gce_resolver.cc
+++ b/lib/src/facts/resolvers/gce_resolver.cc
@@ -191,7 +191,7 @@ namespace facter { namespace facts { namespace resolvers {
             }
         }
 
-        void check_initialized()
+        void check_initialized() const
         {
             if (!_initialized) {
                 throw external::external_fact_exception("expected document to contain an object.");

--- a/lib/src/facts/solaris/zpool_resolver.cc
+++ b/lib/src/facts/solaris/zpool_resolver.cc
@@ -80,7 +80,6 @@ namespace facter { namespace facts { namespace solaris {
     void zpool_resolver::resolve(collection& facts)
     {
         // Solaris ZFS still follows a simple linear versioning
-        string val;
         string version;
         vector<string> nver;
         re_adapter re_zpool_version("ZFS pool version (\\d+)[.]");

--- a/lib/src/facts/zfs/zpool_resolver.cc
+++ b/lib/src/facts/zfs/zpool_resolver.cc
@@ -140,7 +140,6 @@ namespace facter { namespace facts { namespace zfs {
         * Solaris ZFS still follows a simple linear versioning
         */
          string val;
-         string version;
          vector<string> nver;
          re_adapter re_zpool_nversion("\\s*(\\d+)[ ]");
          execution::each_line(zpool_cmd(), {"upgrade", "-v"}, [&] (string& line) {


### PR DESCRIPTION
This commit enables warnings in cppcheck and addresses some warnings and
style errors (including one bug) that was found by cppcheck.

The bug addressed was that openvz detection was always returning an
empty string.