### PR TITLE
(CFACT-178) Update FFI version

### DIFF
--- a/gem/Gemfile
+++ b/gem/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem 'ffi', '~> 1.9.3', :require => false
+gem 'ffi', '~> 1.9.6', :require => false
 gem 'cfacter', :path => File.expand_path("..", __FILE__), :require => false
 
 group :development, :test do

--- a/gem/cfacter.gemspec
+++ b/gem/cfacter.gemspec
@@ -8,5 +8,5 @@ Gem::Specification.new do |s|
   s.homepage    = "http://puppetlabs.com"
   s.license     = 'Apache-2.0'
   s.files       = ['lib/cfacter.rb']
-  s.add_runtime_dependency 'ffi', '1.9.3'
+  s.add_runtime_dependency 'ffi', '~> 1.9.6'
 end


### PR DESCRIPTION
Ruby 2.1.5 requires ffi 1.9.5+; we use ffi 1.9.6 in most cases. Update
the gem and Gemfile to reflect those versions.