### PR TITLE
(maint) Fix Windows build errors under GCC 4.9.

### DIFF
--- a/lib/src/util/windows/registry.cc
+++ b/lib/src/util/windows/registry.cc
@@ -10,7 +10,7 @@ using namespace std;
 namespace facter { namespace util { namespace windows {
 
     registry_exception::registry_exception(string const& message) :
-        registry_exception(message)
+        runtime_error(message)
     {
     }
 

--- a/lib/src/util/windows/wmi.cc
+++ b/lib/src/util/windows/wmi.cc
@@ -19,7 +19,7 @@ using namespace facter::execution;
 namespace facter { namespace util { namespace windows {
 
     wmi_exception::wmi_exception(string const& message) :
-        wmi_exception(message)
+        runtime_error(message)
     {
     }
 

--- a/lib/tests/util/windows/environment.cc
+++ b/lib/tests/util/windows/environment.cc
@@ -23,7 +23,7 @@ TEST(facter_util_environment, search_paths_empty_path) {
     environment::reload_search_paths();
 
     auto paths = environment::search_paths();
-    ASSERT_EQ(0u, count(paths.begin(), paths.end(), ""));
+    ASSERT_EQ(0u, static_cast<unsigned int>(count(paths.begin(), paths.end(), "")));
 
     ASSERT_TRUE(environment::set("PATH", value));
     environment::reload_search_paths();


### PR DESCRIPTION
A few Windows-related types have invalid, self-delegating constructors.

There's a signed/unsigned mismatch in one Windows-related test.