### PR TITLE
(CFACT-169) Provide ruby during cfacter build time where applicable

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -2,7 +2,7 @@ Source: cfacter
 Section: devel
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>> 7), pl-gcc (>= 4.8.2-1puppetlabs3), pl-cmake (>= 2.8.12-1puppetlabs6), pl-libboost-devel (>= 1.55.0-1puppetlabs3), pl-libboost-static (>= 1.55.0-1puppetlabs3), pl-libyaml-cpp-devel (>= 0.5.1-1puppetlabs4), pl-libyaml-cpp-static (>= 0.5.1-1puppetlabs4), libblkid-dev, libcurl4-openssl-dev, libssl-dev
+Build-Depends: debhelper (>> 7), pl-gcc (>= 4.8.2-1puppetlabs3), pl-cmake (>= 2.8.12-1puppetlabs6), pl-libboost-devel (>= 1.55.0-1puppetlabs3), pl-libboost-static (>= 1.55.0-1puppetlabs3), pl-libyaml-cpp-devel (>= 0.5.1-1puppetlabs4), pl-libyaml-cpp-static (>= 0.5.1-1puppetlabs4), libblkid-dev, libcurl4-openssl-dev, libssl-dev, ruby1.9.1 | ruby (>= 1:1.9.3), ruby1.9.1-dev | ruby-dev (>= 1:1.9.3)
 Standards-Version: 3.9.1
 Homepage: http://www.puppetlabs.com
 

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -32,5 +32,8 @@ override_dh_auto_install:
 	$(MAKE) -j$(NUMPROC) install DESTDIR=$(CURDIR)/debian/tmp
 	rm -r $(CURDIR)/debian/tmp$(PREFIX)/include/boost
 
+override_dh_auto_test:
+	$(BUILDPREFIX)/bin/ctest -V
+
 %:
 	dh $@ --parallel=$(NUMPROC)

--- a/ext/redhat/cfacter.spec.erb
+++ b/ext/redhat/cfacter.spec.erb
@@ -1,3 +1,8 @@
+# Only >=el7 and fedora have a sufficient version of ruby available
+%if 0%{?rhel} >= 7 || 0%{?fedora}
+%{!?vendor_ruby: %global vendor_ruby %(ruby -rrbconfig -e "puts RbConfig::CONFIG['vendordir']")}
+%endif
+
 # Building debuginfo is pointless, as this has no symbols.
 %global debug_package %{nil}
 
@@ -22,6 +27,11 @@ Source0:        http://puppetlabs.com/downloads/%{name}/%{name}-%{realversion}.t
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+# Only >=el7 and fedora have a sufficient version of ruby available
+%if 0%{?rhel} >= 7 || 0%{?fedora}
+BuildRequires:  ruby
+BuildRequires:  ruby-devel
+%endif
 BuildRequires:  pl-gcc >= 4.8.2-4
 BuildRequires:  pl-cmake >= 2.8.12-6
 BuildRequires:  pl-libboost-devel >= 1.55.0-4
@@ -90,6 +100,9 @@ rm -rf %{buildroot}
 %{_bindir}/cfacter
 %{_libdir}/libfacter.so*
 %{_includedir}/facter
+%if 0%{?rhel} >= 7 || 0%{?fedora}
+%{vendor_ruby}/cfacter.rb
+%endif
 %doc LICENSE README.md
 
 

--- a/ext/redhat/cfacter.spec.erb
+++ b/ext/redhat/cfacter.spec.erb
@@ -82,6 +82,8 @@ rm -r %{buildroot}%{_includedir}/boost
 %clean
 rm -rf %{buildroot}
 
+%check
+%{build_prefix}/bin/ctest -V
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
With this PR, we're bringing in ruby and ruby-devel to have available during build time. This will let us take advantage of the work done in https://github.com/puppetlabs/cfacter/pull/255 so we can provide the cfacter ruby library, as well as run the full test suite, which will only include the tests against ruby when when a sufficient version of ruby is available.