### PR TITLE
(maint) We are not using an epoch to version cfacter

### DIFF
--- a/ext/redhat/cfacter.spec.erb
+++ b/ext/redhat/cfacter.spec.erb
@@ -92,7 +92,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  1:<%= @rpmversion %>-<%= @rpmrelease %>
+* <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> - <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
 
 * Thu Jun 05 2014 Melissa Stone <melissa@puppetlabs.com> - 1.7.2-1


### PR DESCRIPTION
This was copy pasta that was brought in accidently when I first added in
the build artifacts for cfacter. The digit I am removing here is meant
to correspond to the epoch number of the build. This was required for
facter when we previously messed up the versioning. This is not required
for cfacter. Since this error was only present in the changelog, not the
actual body of the spec file, this change should not impact users.