### PR TITLE
(maint) Remove unneeded forward declarations

### DIFF
--- a/lib/inc/facter/facts/value.hpp
+++ b/lib/inc/facter/facts/value.hpp
@@ -22,8 +22,6 @@ namespace rapidjson {
     template<typename CharType> struct UTF8;
     typedef GenericValue<UTF8<char>, MemoryPoolAllocator<CrtAllocator>> Value;
     typedef MemoryPoolAllocator<CrtAllocator> Allocator;
-    template <typename Encoding, typename Allocator> class GenericDocument;
-    typedef GenericDocument<UTF8<char>, MemoryPoolAllocator<CrtAllocator>> Document;
 }
 
 extern "C" {


### PR DESCRIPTION
This commit removes the forward declarations for
rapidjson::GenericDocument and rapidjson::Document.

The template paramaters do not match those defined in the current master
branch of rapidjson and are not referenced in value.hpp. Removing them will
allow us to build against master.