### PR TITLE
(maint) Remove LOG_NAMESPACE macro.

### DIFF
--- a/exe/cfacter.cc
+++ b/exe/cfacter.cc
@@ -28,11 +28,6 @@ using namespace facter::facts;
 using namespace facter::ruby;
 namespace po = boost::program_options;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "main"
-
 void help(po::options_description& desc)
 {
     boost::nowide::cout <<

--- a/lib/inc/facter/logging/logging.hpp
+++ b/lib/inc/facter/logging/logging.hpp
@@ -18,15 +18,9 @@
 #include <functional>
 
 /**
- * Defines the root logging namespace.
+ * Defines the logging namespace.
  */
-#define LOG_ROOT_NAMESPACE "puppetlabs.facter."
-
-/**
- * Used to declare a logging namespace for a source file.
- * This macro should be redefined before using any logging macro.
- */
-#define LOG_NAMESPACE "default"
+#define LOG_NAMESPACE "puppetlabs.facter"
 
 /**
  * Logs a message.
@@ -36,7 +30,7 @@
  */
 #define LOG_MESSAGE(level, format, ...) \
     if (facter::logging::is_enabled(level)) { \
-        facter::logging::log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, level, format, ##__VA_ARGS__); \
+        facter::logging::log(LOG_NAMESPACE, level, format, ##__VA_ARGS__); \
     }
 /**
  * Logs a trace message.

--- a/lib/src/execution/execution.cc
+++ b/lib/src/execution/execution.cc
@@ -14,11 +14,6 @@ using namespace facter::logging;
 using namespace boost::filesystem;
 using namespace boost::algorithm;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "execution"
-
 namespace facter { namespace execution {
 
     execution_exception::execution_exception(string const& message) :

--- a/lib/src/execution/posix/execution.cc
+++ b/lib/src/execution/posix/execution.cc
@@ -15,11 +15,6 @@ using namespace facter::util::posix;
 using namespace facter::logging;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "execution"
-
 // Declare environ for OSX
 extern char** environ;
 

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -23,11 +23,6 @@ using namespace facter::logging;
 using namespace boost::filesystem;
 using namespace boost::algorithm;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "execution"
-
 namespace facter { namespace execution {
 
     const char *const command_shell = "cmd.exe";

--- a/lib/src/facts/array_value.cc
+++ b/lib/src/facts/array_value.cc
@@ -8,11 +8,6 @@ using namespace std;
 using namespace rapidjson;
 using namespace YAML;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.value.array"
-
 namespace facter { namespace facts {
 
     array_value::array_value(array_value&& other)

--- a/lib/src/facts/bsd/filesystem_resolver.cc
+++ b/lib/src/facts/bsd/filesystem_resolver.cc
@@ -8,11 +8,6 @@ using namespace std;
 using namespace facter::facts;
 using namespace facter::util;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.bsd.filesystem"
-
 namespace facter { namespace facts { namespace bsd {
 
     filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)

--- a/lib/src/facts/bsd/networking_resolver.cc
+++ b/lib/src/facts/bsd/networking_resolver.cc
@@ -12,11 +12,6 @@ using namespace facter::util;
 using namespace facter::util::bsd;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.bsd.networking"
-
 namespace facter { namespace facts { namespace bsd {
 
     networking_resolver::data networking_resolver::collect_data(collection& facts)

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -26,11 +26,6 @@ using namespace rapidjson;
 using namespace YAML;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.collection"
-
 namespace facter { namespace facts {
 
     collection::collection()

--- a/lib/src/facts/external/execution_resolver.cc
+++ b/lib/src/facts/external/execution_resolver.cc
@@ -12,11 +12,6 @@ using namespace facter::execution;
 using namespace facter::facts;
 using namespace facter::facts::external;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.external.execution"
-
 namespace facter { namespace facts { namespace external {
 
     bool execution_resolver::can_resolve(string const& path) const

--- a/lib/src/facts/external/json_resolver.cc
+++ b/lib/src/facts/external/json_resolver.cc
@@ -16,11 +16,6 @@ using namespace facter::facts;
 using namespace facter::util;
 using namespace rapidjson;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.external.json"
-
 namespace facter { namespace facts { namespace external {
 
     // Helper event handler for parsing JSON data

--- a/lib/src/facts/external/text_resolver.cc
+++ b/lib/src/facts/external/text_resolver.cc
@@ -8,11 +8,6 @@
 using namespace std;
 using namespace facter::util;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.external.text"
-
 namespace facter { namespace facts { namespace external {
 
     bool text_resolver::can_resolve(string const& path) const

--- a/lib/src/facts/external/windows/powershell_resolver.cc
+++ b/lib/src/facts/external/windows/powershell_resolver.cc
@@ -14,11 +14,6 @@ using namespace facter::execution;
 using namespace facter::util::windows;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.external.powershell"
-
 namespace facter { namespace facts { namespace external {
 
     bool powershell_resolver::can_resolve(string const& file) const

--- a/lib/src/facts/external/yaml_resolver.cc
+++ b/lib/src/facts/external/yaml_resolver.cc
@@ -12,11 +12,6 @@
 using namespace std;
 using namespace YAML;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.external.yaml"
-
 namespace facter { namespace facts { namespace external {
 
     static void add_value(

--- a/lib/src/facts/linux/disk_resolver.cc
+++ b/lib/src/facts/linux/disk_resolver.cc
@@ -12,11 +12,6 @@ using namespace boost::filesystem;
 using boost::lexical_cast;
 using boost::bad_lexical_cast;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.linux.disk"
-
 namespace facter { namespace facts { namespace linux {
 
     disk_resolver::data disk_resolver::collect_data(collection& facts)

--- a/lib/src/facts/linux/dmi_resolver.cc
+++ b/lib/src/facts/linux/dmi_resolver.cc
@@ -9,11 +9,6 @@ using namespace facter::util;
 using namespace boost::filesystem;
 namespace bs = boost::system;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.linux.dmi"
-
 namespace facter { namespace facts { namespace linux {
 
     dmi_resolver::data dmi_resolver::collect_data(collection& facts)

--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -22,11 +22,6 @@ using namespace boost::filesystem;
 using boost::lexical_cast;
 using boost::bad_lexical_cast;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.linux.filesystem"
-
 namespace facter { namespace facts { namespace linux {
 
     filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)

--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -12,11 +12,6 @@ using namespace std;
 using namespace facter::util;
 using namespace facter::util::posix;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.linux.networking"
-
 namespace facter { namespace facts { namespace linux {
 
     bool networking_resolver::is_link_address(sockaddr const* addr) const

--- a/lib/src/facts/map_value.cc
+++ b/lib/src/facts/map_value.cc
@@ -10,11 +10,6 @@ using namespace facter::util;
 using namespace rapidjson;
 using namespace YAML;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.value.map"
-
 namespace facter { namespace facts {
 
     map_value::map_value(map_value&& other)

--- a/lib/src/facts/osx/dmi_resolver.cc
+++ b/lib/src/facts/osx/dmi_resolver.cc
@@ -4,11 +4,6 @@
 
 using namespace std;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.osx.dmi"
-
 namespace facter { namespace facts { namespace osx {
 
     dmi_resolver::data dmi_resolver::collect_data(collection& facts)

--- a/lib/src/facts/osx/memory_resolver.cc
+++ b/lib/src/facts/osx/memory_resolver.cc
@@ -8,11 +8,6 @@ using namespace std;
 using namespace facter::execution;
 using namespace facter::util;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.osx.memory"
-
 namespace facter { namespace facts { namespace osx {
 
     memory_resolver::data memory_resolver::collect_data(collection& facts)

--- a/lib/src/facts/osx/processor_resolver.cc
+++ b/lib/src/facts/osx/processor_resolver.cc
@@ -5,11 +5,6 @@
 
 using namespace std;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.osx.processor"
-
 namespace facter { namespace facts { namespace osx {
 
     processor_resolver::data processor_resolver::collect_data(collection& facts)

--- a/lib/src/facts/posix/identity_resolver.cc
+++ b/lib/src/facts/posix/identity_resolver.cc
@@ -4,11 +4,6 @@
 #include <pwd.h>
 #include <grp.h>
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.identity"
-
 using namespace std;
 using namespace facter::util;
 

--- a/lib/src/facts/posix/kernel_resolver.cc
+++ b/lib/src/facts/posix/kernel_resolver.cc
@@ -5,11 +5,6 @@
 
 using namespace std;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.kernel"
-
 namespace facter { namespace facts { namespace posix {
 
     kernel_resolver::data kernel_resolver::collect_data(collection& facts)

--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -12,11 +12,6 @@ using namespace std;
 using namespace facter::util;
 using namespace facter::util::posix;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.networking"
-
 namespace facter { namespace facts { namespace posix {
 
     string networking_resolver::address_to_string(sockaddr const* addr, sockaddr const* mask) const

--- a/lib/src/facts/posix/operatingsystem_resolver.cc
+++ b/lib/src/facts/posix/operatingsystem_resolver.cc
@@ -6,11 +6,6 @@
 using namespace std;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.os"
-
 namespace facter { namespace facts { namespace posix {
 
     operating_system_resolver::data operating_system_resolver::collect_data(collection& facts)

--- a/lib/src/facts/posix/processor_resolver.cc
+++ b/lib/src/facts/posix/processor_resolver.cc
@@ -5,11 +5,6 @@
 using namespace std;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.processor"
-
 namespace facter { namespace facts { namespace posix {
 
     processor_resolver::data processor_resolver::collect_data(collection& facts)

--- a/lib/src/facts/posix/ssh_resolver.cc
+++ b/lib/src/facts/posix/ssh_resolver.cc
@@ -21,11 +21,6 @@ using namespace facter::util;
 using namespace boost::filesystem;
 namespace bs = boost::system;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.ssh"
-
 namespace facter { namespace facts { namespace posix {
 
     ssh_resolver::data ssh_resolver::collect_data(collection& facts)

--- a/lib/src/facts/posix/timezone_resolver.cc
+++ b/lib/src/facts/posix/timezone_resolver.cc
@@ -2,11 +2,6 @@
 #include <facter/logging/logging.hpp>
 #include <time.h>
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.posix.timezone"
-
 using namespace std;
 
 namespace facter { namespace facts { namespace posix {

--- a/lib/src/facts/resolver.cc
+++ b/lib/src/facts/resolver.cc
@@ -5,11 +5,6 @@
 
 using namespace std;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.resolver"
-
 namespace facter { namespace facts {
 
     invalid_name_pattern_exception::invalid_name_pattern_exception(string const& message) :

--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -19,11 +19,6 @@ using namespace facter::http;
 using namespace std;
 using namespace facter::util;
 
-#ifdef LOG_NAMESPACE
-    #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.ec2"
-
 namespace facter { namespace facts { namespace resolvers {
 
     ec2_resolver::ec2_resolver() :

--- a/lib/src/facts/resolvers/gce_resolver.cc
+++ b/lib/src/facts/resolvers/gce_resolver.cc
@@ -23,11 +23,6 @@ using namespace std;
 using namespace facter::util;
 using namespace rapidjson;
 
-#ifdef LOG_NAMESPACE
-    #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.gce"
-
 namespace facter { namespace facts { namespace resolvers {
 
     // Helper event handler for parsing JSON data

--- a/lib/src/facts/resolvers/ruby_resolver.cc
+++ b/lib/src/facts/resolvers/ruby_resolver.cc
@@ -11,9 +11,6 @@ using namespace std;
 using namespace facter::util;
 using namespace facter::ruby;
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.ruby"
-
 namespace facter { namespace facts { namespace resolvers {
 
     ruby_resolver::ruby_resolver() :

--- a/lib/src/facts/solaris/disk_resolver.cc
+++ b/lib/src/facts/solaris/disk_resolver.cc
@@ -6,11 +6,6 @@
 using namespace std;
 using namespace facter::util::solaris;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.disk"
-
 namespace facter { namespace facts { namespace solaris {
 
     disk_resolver::data disk_resolver::collect_data(collection& facts)

--- a/lib/src/facts/solaris/dmi_resolver.cc
+++ b/lib/src/facts/solaris/dmi_resolver.cc
@@ -9,11 +9,6 @@ using namespace std;
 using namespace facter::util;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.dmi"
-
 namespace facter { namespace facts { namespace solaris {
 
     dmi_resolver::data dmi_resolver::collect_data(collection& facts)

--- a/lib/src/facts/solaris/filesystem_resolver.cc
+++ b/lib/src/facts/solaris/filesystem_resolver.cc
@@ -21,11 +21,6 @@ using namespace facter::execution;
 using namespace facter::util::solaris;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.filesystem"
-
 namespace facter { namespace facts { namespace solaris {
 
     filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)

--- a/lib/src/facts/solaris/kernel_resolver.cc
+++ b/lib/src/facts/solaris/kernel_resolver.cc
@@ -4,11 +4,6 @@
 
 using namespace std;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.kernel"
-
 namespace facter { namespace facts { namespace solaris {
 
     kernel_resolver::data kernel_resolver::collect_data(collection& facts)

--- a/lib/src/facts/solaris/memory_resolver.cc
+++ b/lib/src/facts/solaris/memory_resolver.cc
@@ -13,11 +13,6 @@ using namespace std;
 using namespace facter::util;
 using namespace facter::util::solaris;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.memory"
-
 namespace facter { namespace facts { namespace solaris {
 
     memory_resolver::data memory_resolver::collect_data(collection& facts)

--- a/lib/src/facts/solaris/networking_resolver.cc
+++ b/lib/src/facts/solaris/networking_resolver.cc
@@ -12,11 +12,6 @@ using namespace facter::util::posix;
 using namespace facter::util;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.networking"
-
 namespace facter { namespace facts { namespace solaris {
 
     networking_resolver::data networking_resolver::collect_data(collection& facts)

--- a/lib/src/facts/solaris/processor_resolver.cc
+++ b/lib/src/facts/solaris/processor_resolver.cc
@@ -7,11 +7,6 @@
 using namespace std;
 using namespace facter::util::solaris;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.processor"
-
 /*
  * https://blogs.oracle.com/mandalika/entry/solaris_show_me_the_cpu
  * What we want to do is to count the distinct number of chip_id (#nproc),

--- a/lib/src/facts/solaris/zfs_resolver.cc
+++ b/lib/src/facts/solaris/zfs_resolver.cc
@@ -15,11 +15,6 @@ using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.zfs"
-
 namespace facter { namespace facts { namespace solaris {
 
     string zfs_resolver::zfs_cmd()

--- a/lib/src/facts/solaris/zone_resolver.cc
+++ b/lib/src/facts/solaris/zone_resolver.cc
@@ -18,11 +18,6 @@ using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.zone"
-
 namespace facter { namespace facts { namespace solaris {
 
     zone_resolver::zone_resolver() :

--- a/lib/src/facts/solaris/zpool_resolver.cc
+++ b/lib/src/facts/solaris/zpool_resolver.cc
@@ -15,11 +15,6 @@ using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::execution;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.solaris.zpool"
-
 namespace facter { namespace facts { namespace solaris {
 
     string zpool_resolver::zpool_cmd()

--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -28,11 +28,6 @@ using namespace facter::util::windows;
 using namespace facter::facts::external;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.collection"
-
 namespace facter { namespace facts {
 
     vector<string> collection::get_external_fact_directories()

--- a/lib/src/facts/windows/dmi_resolver.cc
+++ b/lib/src/facts/windows/dmi_resolver.cc
@@ -5,11 +5,6 @@
 using namespace std;
 using namespace facter::util::windows;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.windows.dmi"
-
 namespace facter { namespace facts { namespace windows {
 
     dmi_resolver::dmi_resolver(shared_ptr<wmi> wmi_conn) :

--- a/lib/src/facts/windows/identity_resolver.cc
+++ b/lib/src/facts/windows/identity_resolver.cc
@@ -6,9 +6,6 @@
 #include <facter/util/windows/windows.hpp>
 #include <security.h>
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.windows.identity"
-
 using namespace std;
 using namespace facter::util;
 using namespace facter::util::windows;

--- a/lib/src/facts/windows/kernel_resolver.cc
+++ b/lib/src/facts/windows/kernel_resolver.cc
@@ -11,9 +11,6 @@
 using namespace std;
 using namespace facter::util::windows;
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.windows.kernel"
-
 namespace facter { namespace facts { namespace windows {
 
     static boost::optional<string> get_release()

--- a/lib/src/facts/windows/memory_resolver.cc
+++ b/lib/src/facts/windows/memory_resolver.cc
@@ -4,11 +4,6 @@
 #include <facter/logging/logging.hpp>
 #include <psapi.h>
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.windows.memory_resolver"
-
 using namespace facter::util::windows;
 
 namespace facter { namespace facts { namespace windows {

--- a/lib/src/facts/windows/networking_resolver.cc
+++ b/lib/src/facts/windows/networking_resolver.cc
@@ -20,9 +20,6 @@ using namespace facter::util;
 using namespace facter::util::windows;
 using namespace boost::algorithm;
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.windows.networking"
-
 namespace facter { namespace facts { namespace windows {
 
     static string get_computername(COMPUTER_NAME_FORMAT nameFormat)

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -16,11 +16,6 @@ using namespace facter::util;
 using namespace facter::util::windows;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.windows.os"
-
 namespace facter { namespace facts { namespace windows {
 
     static string get_hardware()

--- a/lib/src/facts/windows/timezone_resolver.cc
+++ b/lib/src/facts/windows/timezone_resolver.cc
@@ -2,9 +2,6 @@
 #include <facter/logging/logging.hpp>
 #include <ctime>
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.windows.timezone"
-
 using namespace std;
 
 namespace facter { namespace facts { namespace windows {

--- a/lib/src/facts/windows/uptime_resolver.cc
+++ b/lib/src/facts/windows/uptime_resolver.cc
@@ -5,9 +5,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.windows.uptime_resolver"
-
 namespace facter { namespace facts { namespace windows {
 
     using namespace std;

--- a/lib/src/facts/windows/virtualization_resolver.cc
+++ b/lib/src/facts/windows/virtualization_resolver.cc
@@ -12,9 +12,6 @@ using namespace std;
 using namespace facter::facts;
 using namespace facter::util::windows;
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facts.windows.virtualization"
-
 namespace facter { namespace facts { namespace windows {
 
     virtualization_resolver::virtualization_resolver(shared_ptr<wmi> wmi_conn) :

--- a/lib/src/facts/zfs/zfs_resolver.cc
+++ b/lib/src/facts/zfs/zfs_resolver.cc
@@ -12,16 +12,10 @@
 #include <string>
 #include <map>
 
-
 using namespace std;
 using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::execution;
-
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.zfs.zfs"
 
 namespace facter { namespace facts { namespace zfs {
 

--- a/lib/src/facts/zfs/zpool_resolver.cc
+++ b/lib/src/facts/zfs/zpool_resolver.cc
@@ -12,16 +12,10 @@
 #include <string>
 #include <map>
 
-
 using namespace std;
 using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::execution;
-
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "facts.zfs.zpool"
 
 namespace facter { namespace facts { namespace zfs {
 

--- a/lib/src/http/client.cc
+++ b/lib/src/http/client.cc
@@ -7,11 +7,6 @@
 #include <boost/algorithm/string.hpp>
 #include <sstream>
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "http.client"
-
 using namespace std;
 using namespace facter::util;
 

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -15,11 +15,6 @@ using namespace facter::facts;
 using namespace facter::util;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby"
-
 namespace facter { namespace ruby {
 
 #define LOAD_SYMBOL(x) x(reinterpret_cast<decltype(x)>(library.find_symbol(#x, true)))

--- a/lib/src/ruby/fact.cc
+++ b/lib/src/ruby/fact.cc
@@ -10,11 +10,6 @@
 using namespace std;
 using namespace facter::facts;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby"
-
 namespace facter { namespace ruby {
 
     fact::fact() :

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -22,11 +22,6 @@ using namespace facter::execution;
 using namespace facter::logging;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby"
-
 namespace facter { namespace ruby {
 
     /**

--- a/lib/src/ruby/posix/api.cc
+++ b/lib/src/ruby/posix/api.cc
@@ -12,11 +12,6 @@ using namespace facter::util;
 using namespace facter::execution;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby"
-
 namespace facter { namespace ruby {
 
     dynamic_library api::find_library()

--- a/lib/src/ruby/resolution.cc
+++ b/lib/src/ruby/resolution.cc
@@ -5,11 +5,6 @@
 using namespace std;
 using namespace facter::facts;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby"
-
 namespace facter { namespace ruby {
 
     resolution::resolution() :

--- a/lib/src/ruby/windows/api.cc
+++ b/lib/src/ruby/windows/api.cc
@@ -11,11 +11,6 @@ using namespace facter::util;
 using namespace facter::execution;
 using namespace boost::filesystem;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby"
-
 namespace facter { namespace ruby {
 
     dynamic_library api::find_library()

--- a/lib/src/util/posix/dynamic_library.cc
+++ b/lib/src/util/posix/dynamic_library.cc
@@ -5,11 +5,6 @@
 
 using namespace std;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "util.posix.dynamic_library"
-
 namespace facter { namespace util {
 
     dynamic_library dynamic_library::find_by_pattern(std::string const& pattern)

--- a/lib/src/util/windows/dynamic_library.cc
+++ b/lib/src/util/windows/dynamic_library.cc
@@ -12,11 +12,6 @@ using namespace std;
 using namespace facter::util;
 using namespace facter::util::windows;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "util.windows.dynamic_library"
-
 namespace facter { namespace util {
 
     dynamic_library dynamic_library::find_by_pattern(std::string const& pattern)

--- a/lib/src/util/windows/wmi.cc
+++ b/lib/src/util/windows/wmi.cc
@@ -13,9 +13,6 @@
 using namespace std;
 using namespace facter::execution;
 
-#undef LOG_NAMESPACE
-#define LOG_NAMESPACE "facter.util.windows.wmi"
-
 namespace facter { namespace util { namespace windows {
 
     wmi_exception::wmi_exception(string const& message) :

--- a/lib/tests/logging/logging.cc
+++ b/lib/tests/logging/logging.cc
@@ -9,11 +9,6 @@ using namespace std;
 using namespace facter::logging;
 namespace sinks = boost::log::sinks;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "logging.test"
-
 class custom_log_appender :
     public sinks::basic_formatted_sink_backend<char, sinks::synchronized_feeding>
 {
@@ -73,7 +68,7 @@ TEST_F(facter_logging, trace) {
     LOG_TRACE("testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("TRACE", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::trace)) + "testing 1 2 3" + colorize(), _appender->last_message());
-    log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, log_level::trace, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::trace, "testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("TRACE", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::trace)) + "testing 1 2 3" + colorize(), _appender->last_message());
 }
@@ -83,7 +78,7 @@ TEST_F(facter_logging, debug) {
     LOG_DEBUG("testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("DEBUG", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::debug)) + "testing 1 2 3" + colorize(), _appender->last_message());
-    log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, log_level::debug, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::debug, "testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("DEBUG", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::debug)) + "testing 1 2 3" + colorize(), _appender->last_message());
 }
@@ -93,7 +88,7 @@ TEST_F(facter_logging, info) {
     LOG_INFO("testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("INFO", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::info)) + "testing 1 2 3" + colorize(), _appender->last_message());
-    log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, log_level::info, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::info, "testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("INFO", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::info)) + "testing 1 2 3" + colorize(), _appender->last_message());
 }
@@ -103,7 +98,7 @@ TEST_F(facter_logging, warning) {
     LOG_WARNING("testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("WARN", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::warning)) + "testing 1 2 3" + colorize(), _appender->last_message());
-    log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, log_level::warning, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::warning, "testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("WARN", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::warning)) + "testing 1 2 3" + colorize(), _appender->last_message());
 }
@@ -113,7 +108,7 @@ TEST_F(facter_logging, error) {
     LOG_ERROR("testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("ERROR", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::error)) + "testing 1 2 3" + colorize(), _appender->last_message());
-    log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, log_level::error, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::error, "testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("ERROR", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::error)) + "testing 1 2 3" + colorize(), _appender->last_message());
 }
@@ -123,7 +118,7 @@ TEST_F(facter_logging, fatal) {
     LOG_FATAL("testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("FATAL", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::fatal)) + "testing 1 2 3" + colorize(), _appender->last_message());
-    log(LOG_ROOT_NAMESPACE LOG_NAMESPACE, log_level::fatal, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::fatal, "testing %1% %2% %3%", 1, "2", 3.0);
     ASSERT_EQ("FATAL", _appender->last_level());
     ASSERT_EQ(string(colorize(log_level::fatal)) + "testing 1 2 3" + colorize(), _appender->last_message());
 }

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -27,11 +27,6 @@ using namespace facter::logging;
 using testing::ElementsAre;
 namespace sinks = boost::log::sinks;
 
-#ifdef LOG_NAMESPACE
-  #undef LOG_NAMESPACE
-#endif
-#define LOG_NAMESPACE "ruby.test"
-
 class ruby_log_appender :
     public sinks::basic_formatted_sink_backend<char, sinks::synchronized_feeding>
 {


### PR DESCRIPTION
Removing the LOG_NAMESPACE redefinitions from libfacter.  We now use a single
namespace for all of libfacter's output.

This work is needed if we plan on extracting libfacter's logging into a
common library.  The specific namespaces were not adding any value for
libfacter users and only made the code a little more complicated and
brittle in terms of unity builds.