### PR TITLE
(CFACT-179) Fix partitions label and add partlabel.

### DIFF
--- a/lib/inc/facter/facts/resolvers/filesystem_resolver.hpp
+++ b/lib/inc/facter/facts/resolvers/filesystem_resolver.hpp
@@ -93,7 +93,7 @@ namespace facter { namespace facts { namespace resolvers {
             std::string name;
 
             /**
-             * Stores the filename of the partition.
+             * Stores the file system of the partition.
              */
             std::string filesystem;
 
@@ -103,19 +103,24 @@ namespace facter { namespace facts { namespace resolvers {
             uint64_t size;
 
             /**
-             * Stores the UUID of the partition.
+             * Stores the UUID of the file system.
              */
             std::string uuid;
 
             /**
-             * Stores the PARTUUID of the partition.
+             * Stores the UUID of the GPT partition.
              */
-            std::string partuuid;
+            std::string partition_uuid;
 
             /**
-             * Stores the partition label.
+             * Stores the label of the file system.
              */
             std::string label;
+
+            /**
+             * Stores the label of the GPT partition.
+             */
+            std::string partition_label;
 
             /**
              * Stores the partition mountpoint.

--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -134,12 +134,14 @@ namespace facter { namespace facts { namespace linux {
                     boost::to_lower(attribute);
                     if (attribute == "type") {
                         ptr = &part.filesystem;
-                    } else if (attribute == "partlabel") {
+                    } else if (attribute == "label") {
                         ptr = &part.label;
+                    } else if (attribute == "partlabel") {
+                        ptr = &part.partition_label;
                     } else if (attribute == "uuid") {
                         ptr = &part.uuid;
                     } else if (attribute == "partuuid") {
-                        ptr = &part.partuuid;
+                        ptr = &part.partition_uuid;
                     }
                     if (!ptr) {
                         continue;

--- a/lib/src/facts/resolvers/filesystem_resolver.cc
+++ b/lib/src/facts/resolvers/filesystem_resolver.cc
@@ -84,17 +84,20 @@ namespace facter { namespace facts { namespace resolvers {
                 if (!partition.filesystem.empty()) {
                     value->add("filesystem", make_value<string_value>(move(partition.filesystem)));
                 }
-                if (!partition.label.empty()) {
-                    value->add("label", make_value<string_value>(move(partition.label)));
-                }
                 if (!partition.mount.empty()) {
                     value->add("mount", make_value<string_value>(move(partition.mount)));
                 }
-                if (!partition.partuuid.empty()) {
-                    value->add("partuuid", make_value<string_value>(move(partition.partuuid)));
+                if (!partition.label.empty()) {
+                    value->add("label", make_value<string_value>(move(partition.label)));
+                }
+                if (!partition.partition_label.empty()) {
+                    value->add("partlabel", make_value<string_value>(move(partition.partition_label)));
                 }
                 if (!partition.uuid.empty()) {
                     value->add("uuid", make_value<string_value>(move(partition.uuid)));
+                }
+                if (!partition.partition_uuid.empty()) {
+                    value->add("partuuid", make_value<string_value>(move(partition.partition_uuid)));
                 }
                 value->add("size_bytes", make_value<integer_value>(partition.size));
                 value->add("size", make_value<string_value>(si_string(partition.size)));

--- a/lib/tests/facts/resolvers/filesystem_resolver.cc
+++ b/lib/tests/facts/resolvers/filesystem_resolver.cc
@@ -38,15 +38,16 @@ struct test_filesystem_resolver : filesystem_resolver
         filesystems.emplace(move(filesystem));
     }
 
-    void add_partition(string name, string filesystem, uint64_t size, string uuid, string partuuid, string label, string mount)
+    void add_partition(string name, string filesystem, uint64_t size, string uuid, string partuuid, string label, string partlabel, string mount)
     {
         partition p;
         p.name = move(name);
         p.filesystem = move(filesystem);
         p.size = size;
         p.uuid = move(uuid);
-        p.partuuid = move(partuuid);
+        p.partition_uuid = move(partuuid);
         p.label = move(label);
+        p.partition_label = move(partlabel);
         p.mount = move(mount);
         partitions.emplace_back(move(p));
     }
@@ -172,7 +173,7 @@ TEST(facter_facts_resolvers_filesystem_resolver, partitions)
 
     for (unsigned int i = 0; i < count; ++i) {
         string num = to_string(i);
-        resolver->add_partition("partition" + num, "filesystem" + num, 12345 + i, "uuid" + num, "partuuid" + num, "label" + num, "mount" + num);
+        resolver->add_partition("partition" + num, "filesystem" + num, 12345 + i, "uuid" + num, "partuuid" + num, "label" + num, "partlabel" + num, "mount" + num);
     }
 
     facts.add(move(resolver));
@@ -186,7 +187,7 @@ TEST(facter_facts_resolvers_filesystem_resolver, partitions)
 
         auto partition = partitions->get<map_value>("partition" + num);
         ASSERT_NE(nullptr, partition);
-        ASSERT_EQ(7u, partition->size());
+        ASSERT_EQ(8u, partition->size());
 
         auto filesystem = partition->get<string_value>("filesystem");
         ASSERT_NE(nullptr, filesystem);
@@ -195,6 +196,10 @@ TEST(facter_facts_resolvers_filesystem_resolver, partitions)
         auto label = partition->get<string_value>("label");
         ASSERT_NE(nullptr, label);
         ASSERT_EQ("label" + num, label->value());
+
+        auto partlabel = partition->get<string_value>("partlabel");
+        ASSERT_NE(nullptr, partlabel);
+        ASSERT_EQ("partlabel" + num, partlabel->value());
 
         auto mount = partition->get<string_value>("mount");
         ASSERT_NE(nullptr, mount);


### PR DESCRIPTION
The partition label (for GPT partitions) was being reported as the
"label" attribute instead of the expected file system label.

Added "partlabel" attribute to denote the GPT partition label and changed the
"label" attribute to denote the file system label.  This matches what
blkid would output.