### PR TITLE
(CFACT-181) Allow dynamic assignment of variables

### DIFF
--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -1,3 +1,13 @@
+### Set variables from command line
+# $arch => Choose 32 or 64-bit build
+# $cores => Set the number of cores to use for parallel builds
+# $buildSource => Choose whether to download pre-built libraries or build from source
+param (
+[string] $arch=64,
+[string] $cores=2,
+[string] $buildSource=$FALSE
+)
+
 if (!(Test-Path $env:TEMP)) {
     $env:TEMP='C:\cygwin64\tmp'
 }
@@ -9,14 +19,10 @@ if (!(Test-Path $env:TEMP)) {
 ## Setup the working directory
 $sourceDir=$pwd
 
-## Set the number of cores to use for parallel builds
-$cores=2
+echo $arch
+echo $cores
+echo $buildSource
 
-## Choose whether to download pre-built libraries or build from source
-$buildSource=$FALSE
-
-## Choose 32 or 64-bit build
-$arch=64
 
 $mingwVerNum = "4.8.3"
 $mingwVerChoco = "${mingwVerNum}.20141208"
@@ -52,6 +58,9 @@ if ($arch -eq 64) {
   choco install mingw -Version "${mingwVerChoco}" -params "/exception:${mingwExceptions} /threads:${mingwThreads}" -x86
 }
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+if ($arch -eq 32) {
+  $env:PATH += "C:\tools\mingw32\bin;"
+}
 $env:PATH += [Environment]::GetFolderPath('ProgramFilesX86') + "\git\cmd"
 echo $env:PATH
 cd $sourceDir

--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -25,7 +25,7 @@ if ($arch -eq 64) {
   $mingwExceptions = "seh"
   $mingwArch = "x86_64"
 } else {
-  $mingwExceptions = "dwarf"
+  $mingwExceptions = "sjlj"
   $mingwArch = "i686"
 }
 $mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExceptions}"
@@ -46,7 +46,11 @@ choco install git.install -Version 1.9.5
 choco install ruby -Version 2.1.5
 choco install python -Version 3.4.2
 choco install doxygen.install -Version 1.8.8
-choco install mingw -Version "${mingwVerChoco}" -params "/exception:${mingwExceptions} /threads:${mingwThreads}"
+if ($arch -eq 64) {
+  choco install mingw -Version "${mingwVerChoco}" -params "/exception:${mingwExceptions} /threads:${mingwThreads}"
+} else {
+  choco install mingw -Version "${mingwVerChoco}" -params "/exception:${mingwExceptions} /threads:${mingwThreads}" -x86
+}
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 $env:PATH += [Environment]::GetFolderPath('ProgramFilesX86') + "\git\cmd"
 echo $env:PATH


### PR DESCRIPTION
We need to update the powershell script used for building cfacter on windows to allow us to specify which architecture to build for. In allowing this update, we also need to update this script to fix certain issues when building 32-bit.