### PR TITLE
(CFACT-200) Fix output of custom fact values with UTF8 characters.

### DIFF
--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -80,7 +80,7 @@ namespace facter { namespace ruby {
                 temp = ruby.rb_funcall(value, ruby.rb_intern("to_s"), 0);
             }
 
-            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(temp, ruby.rb_intern("size"), 0)));
+            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(temp, ruby.rb_intern("bytesize"), 0)));
             char const* str = ruby.rb_string_value_ptr(&temp);
             json.SetString(str, size, allocator);
             return;
@@ -138,7 +138,7 @@ namespace facter { namespace ruby {
                 temp = ruby.rb_funcall(value, ruby.rb_intern("to_s"), 0);
             }
 
-            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(temp, ruby.rb_intern("size"), 0)));
+            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(temp, ruby.rb_intern("bytesize"), 0)));
             char const* str = ruby.rb_string_value_ptr(&temp);
 
             if (quoted) {
@@ -202,7 +202,7 @@ namespace facter { namespace ruby {
                     key = ruby.rb_funcall(key, ruby.rb_intern("to_s"), 0);
                 }
 
-                size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(key, ruby.rb_intern("size"), 0)));
+                size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(key, ruby.rb_intern("bytesize"), 0)));
                 char const* str = ruby.rb_string_value_ptr(&key);
 
                 fill_n(ostream_iterator<char>(os), level * 2, ' ');

--- a/lib/tests/fixtures/ruby/uniᐁdir/customfacts™.rb
+++ b/lib/tests/fixtures/ruby/uniᐁdir/customfacts™.rb
@@ -1,5 +1,6 @@
-Facter.add('somefact') do
+# encoding: utf-8
+Facter.add('somefact™') do
   setcode do
-    'other'
+    'other™'
   end
 end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -250,7 +250,7 @@ vector<ruby_test_parameters> single_fact_tests = {
     ruby_test_parameters("empty_fact_with_value.rb", "foo", "{\n  int => 1,\n  bool_true => true,\n  bool_false => false,\n  double => 12.34,\n  string => \"foo\",\n  array => [\n    1,\n    2,\n    3\n  ]\n}"),
     ruby_test_parameters("empty_command.rb", log_level::error, { { "ERROR", "expected a non-empty String for first argument" } }, true),
     ruby_test_parameters("simple_command.rb", "foo", "\"bar\""),
-    ruby_test_parameters("uni\u1401dir/customfacts\u2122.rb", "somefact", "\"other\""),
+    ruby_test_parameters("uni\u1401dir/customfacts\u2122.rb", "somefact\u2122", "\"other\u2122\""),
     ruby_test_parameters("confine_missing_fact.rb", "foo", { { "kernel", "linux" } }),
     ruby_test_parameters("bad_command.rb", "foo"),
     ruby_test_parameters("simple_confine.rb", "foo", "\"bar\"", { { "someFact", "someValue" } }),


### PR DESCRIPTION
When outputting custom fact values, we were using String#size to get the
size of the strings to write to JSON or to an output stream.

This uses the character size of the string, not the byte size of the
string.  As such, strings were incorrectly truncated when multi-byte
characters were present in the string.

The fix is to use String#bytesize to properly write out all the bytes in
the string.