### PR TITLE
(CFACT-199) Implement support for setting fact values from environment.

### DIFF
--- a/Extensibility.md
+++ b/Extensibility.md
@@ -30,8 +30,8 @@ Native Facter implements a Ruby compatibility layer to support simple and aggreg
 Native Facter searches for a MRI Ruby library to load and initializes a Ruby VM as needed
 to resolve custom facts.
 
-The environment variable `FACTER_RUBY` can be used to explicitly instruct native Facter to use
-a particular Ruby library (e.g. `FACTER_RUBY=/usr/local/lib/libruby.so.1.9.3`).  If not set, native Facter will search for and load the highest
+The environment variable `FACTERRUBY` can be used to explicitly instruct native Facter to use
+a particular Ruby library (e.g. `FACTERRUBY=/usr/local/lib/libruby.so.1.9.3`).  If not set, native Facter will search for and load the highest
 version Ruby library on the system.
 
 **Ruby 1.8.x is not supported by native Facter.  Please use Ruby 1.9.3 or later.**

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ MinGW-w64 is used for full C++11 support, and Chocolatey to install some tools. 
 
 For the remaining tasks, build commands can be executed in the shell from Start > MinGW-w64 project > Run Terminal
 
-*   select an install location for dependencies, such as C:\tools or cmake\release\ext; we'll refer to it as $install
+*   select an install location for dependencies, such as C:\\tools or cmake\\release\\ext; we'll refer to it as $install
 
 *   build Boost - http://sourceforge.net/projects/boost/files/latest/download
 

--- a/exe/cfacter.cc
+++ b/exe/cfacter.cc
@@ -246,6 +246,9 @@ int main(int argc, char **argv)
             facts.add_external_facts(external_directories);
         }
 
+        // Add the environment facts
+        facts.add_environment_facts();
+
         if (ruby) {
             module mod(facts, custom_directories);
             mod.resolve_facts();

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -101,10 +101,15 @@ namespace facter { namespace facts {
 
         /**
          * Adds external facts to the fact collection.
-         * If external facts are present, all facts will be resolved prior to adding the external facts.
          * @param directories The directories to search for external facts.  If empty, the default search paths will be used.
          */
         void add_external_facts(std::vector<std::string> const& directories = {});
+
+        /**
+         * Adds facts defined via "FACTER_xyz" environment variables.
+         * @param callback The callback that is called with the name of each fact added from the environment.
+         */
+        void add_environment_facts(std::function<void(std::string const&)> callback = nullptr);
 
         /**
          * Removes a resolver from the fact collection.

--- a/lib/inc/facter/util/environment.hpp
+++ b/lib/inc/facter/util/environment.hpp
@@ -57,6 +57,12 @@ namespace facter { namespace util {
          * Force search program paths to be reloaded.
          */
         static void reload_search_paths();
+
+        /**
+         * Enumerates the environment variables for the current process.
+         * @param callback The callback to call for each environment variable (passes the variable name and value).
+         */
+        static void each(std::function<bool(std::string&, std::string&)> callback);
     };
 
 }}

--- a/lib/inc/facter/util/locale.hpp
+++ b/lib/inc/facter/util/locale.hpp
@@ -4,14 +4,12 @@
 */
 #pragma once
 
-
-
 namespace facter { namespace util {
 
     /**
-     * Sets the locale to the specified locale id, and imbues it in boost::filesystem
-     * @args id The locale ID, defaults to the system default
+     * Sets the locale to the specified locale id and imbues it in boost::filesystem.
+     * @param id The locale ID, defaults to the system default.
      */
     void set_locale(std::string const& id = "");
 
-}}
+}}  // namespace facter::util

--- a/lib/inc/facter/util/windows/registry.hpp
+++ b/lib/inc/facter/util/windows/registry.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * Declares utility functions for interacting with the Windows registry.
+ */
 #pragma once
 
 #include <string>

--- a/lib/inc/facter/util/windows/system_error.hpp
+++ b/lib/inc/facter/util/windows/system_error.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * Declares utility functions for getting Windows error messages.
+ */
 #pragma once
 
 #include <string>
@@ -6,14 +10,14 @@ namespace facter { namespace util { namespace windows {
     /**
      * This is a wrapper for printing error messages on Windows.
      * @param err The Windows error code.
-     * @return A formatted string "<error_message> (<error_code>)"
+     * @return A formatted string "<error_message> (<error_code>)".
      */
     std::string system_error(unsigned long err);
 
     /**
      * This is a wrapper for printing error messages on Windows.
      * It calls system_error with GetLastError as the argument.
-     * @return A formatted string "<error_message> (<error_code>)"
+     * @return A formatted string "<error_message> (<error_code>)".
      */
     std::string system_error();
 }}}  // namespace facter::util::windows

--- a/lib/inc/facter/util/windows/windows.hpp
+++ b/lib/inc/facter/util/windows/windows.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * Utility header for including Windows API headers.
+ */
 #pragma once
 
 // Windows has several header files with fixed dependency ordering. Include interdependent headers here,

--- a/lib/inc/facter/util/windows/wmi.hpp
+++ b/lib/inc/facter/util/windows/wmi.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * Declares utility functions for interacting with Windows Management Instrumentation.
+ */
 #pragma once
 
 #include <facter/util/scoped_resource.hpp>

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -170,6 +170,27 @@ namespace facter { namespace facts {
         }
     }
 
+    void collection::add_environment_facts(function<void(string const& name)> callback)
+    {
+        environment::each([&](string& name, string& value) {
+            // If the variable starts with "FACTER_", the remainder of the variable is the fact name
+            if (!boost::istarts_with(name, "FACTER_")) {
+                return true;
+            }
+
+            auto fact_name = name.substr(7);
+            boost::to_lower(fact_name);
+            LOG_DEBUG("setting fact \"%1%\" based on the value of environment variable \"%2%\".", fact_name, name);
+
+            // Add the value based on the environment variable
+            add(fact_name, make_value<string_value>(move(value)));
+            if (callback) {
+                callback(fact_name);
+            }
+            return true;
+        });
+    }
+
     void collection::remove(shared_ptr<resolver> const& res)
     {
         if (!res) {

--- a/lib/src/ruby/fact.cc
+++ b/lib/src/ruby/fact.cc
@@ -5,10 +5,12 @@
 #include <facter/ruby/ruby_value.hpp>
 #include <facter/facts/collection.hpp>
 #include <facter/logging/logging.hpp>
+#include <facter/util/environment.hpp>
 #include <algorithm>
 
 using namespace std;
 using namespace facter::facts;
+using namespace facter::util;
 
 namespace facter { namespace ruby {
 
@@ -72,9 +74,9 @@ namespace facter { namespace ruby {
             return res_first->weight() > res_second->weight();
         });
 
-        vector<VALUE>::iterator it;
-
         _resolving = true;
+
+        vector<VALUE>::iterator it;
         ruby.rescue([&]() {
             volatile VALUE value = ruby.nil_value();
 
@@ -103,15 +105,20 @@ namespace facter { namespace ruby {
             return 0;
         });
 
+        bool add = true;
         if (ruby.is_nil(_value)) {
             // Check to see the value is in the collection
             auto value = facts[ruby.to_string(_name)];
             if (value) {
+                // Already in collection, do not add
+                add = false;
                 _value = ruby.to_ruby(value);
             }
         }
 
-        facts.add(ruby.to_string(_name), ruby.is_nil(_value) ? nullptr : make_value<ruby::ruby_value>(_value));
+        if (add) {
+            facts.add(ruby.to_string(_name), ruby.is_nil(_value) ? nullptr : make_value<ruby::ruby_value>(_value));
+        }
 
         _resolving = false;
         return _value;

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -362,6 +362,13 @@ namespace facter { namespace ruby {
         if (_collection.empty()) {
             _collection.add_default_facts();
             _collection.add_external_facts(_external_search_paths);
+
+            auto const& ruby = *api::instance();
+            _collection.add_environment_facts([&](string const& name) {
+                // Create a fact and explicitly set the value
+                // We honor environment variables above custom fact resolutions
+                ruby.to_native<fact>(create_fact(ruby.utf8_value(name)))->value(ruby.to_ruby(_collection[name]));
+            });
         }
         return _collection;
     }

--- a/lib/src/ruby/posix/api.cc
+++ b/lib/src/ruby/posix/api.cc
@@ -25,7 +25,7 @@ namespace facter { namespace ruby {
         // Next try an environment variable
         // This allows users to directly specify the ruby version to use
         string value;
-        if (environment::get("FACTER_RUBY", value)) {
+        if (environment::get("FACTERRUBY", value)) {
             if (library.load(value)) {
                 return library;
             } else {

--- a/lib/src/ruby/windows/api.cc
+++ b/lib/src/ruby/windows/api.cc
@@ -22,9 +22,9 @@ namespace facter { namespace ruby {
             return library;
         }
 
-        // 2. Check the FACTER_RUBY environment variable
+        // 2. Check the FACTERRUBY environment variable
         string value;
-        if (environment::get("FACTER_RUBY", value)) {
+        if (environment::get("FACTERRUBY", value)) {
             if (library.load(value)) {
                 return library;
             } else {

--- a/lib/src/util/posix/environment.cc
+++ b/lib/src/util/posix/environment.cc
@@ -1,6 +1,7 @@
 #include <facter/util/environment.hpp>
 #include <boost/algorithm/string.hpp>
 #include <functional>
+#include <unistd.h>
 
 using namespace std;
 
@@ -45,6 +46,27 @@ namespace facter { namespace util {
     void environment::reload_search_paths()
     {
         helper = search_path_helper();
+    }
+
+    void environment::each(function<bool(string&, string&)> callback)
+    {
+        // Enumerate all environment variables
+        for (char const* const* variable = environ; *variable; ++variable) {
+            string pair = *variable;
+            string name;
+            string value;
+
+            auto pos = pair.find('=');
+            if (pos == string::npos) {
+                name = move(pair);
+            } else {
+                name = pair.substr(0, pos);
+                value = pair.substr(pos + 1);
+            }
+            if (!callback(name, value)) {
+                break;
+            }
+        }
     }
 
 }}  // namespace facter::util

--- a/lib/tests/fixtures/ruby/facterversion.rb
+++ b/lib/tests/fixtures/ruby/facterversion.rb
@@ -1,0 +1,8 @@
+Facter.add(:facterversion) do
+    setcode do
+        # This tests a custom fact that attempts to override a built-in fact
+        # but does not resolve to a value; the built-in fact should
+        # not be overridden
+        nil
+    end
+end

--- a/lib/tests/fixtures/ruby/ruby.rb
+++ b/lib/tests/fixtures/ruby/ruby.rb
@@ -1,0 +1,5 @@
+Facter.add(:ruby) do
+    setcode do
+        'override'
+    end
+end

--- a/lib/tests/util/environment.cc
+++ b/lib/tests/util/environment.cc
@@ -8,36 +8,74 @@ using namespace facter::util;
 
 TEST(facter_util_environment, get) {
     string value;
-    ASSERT_FALSE(environment::get("FACTER_ENV_TEST", value));
+    ASSERT_FALSE(environment::get("FACTERTEST", value));
     ASSERT_EQ("", value);
-    boost::nowide::setenv("FACTER_ENV_TEST", "FOO", 1);
-    ASSERT_TRUE(environment::get("FACTER_ENV_TEST", value));
+    boost::nowide::setenv("FACTERTEST", "FOO", 1);
+    ASSERT_TRUE(environment::get("FACTERTEST", value));
     ASSERT_EQ("FOO", value);
-    boost::nowide::unsetenv("FACTER_ENV_TEST");
+    boost::nowide::unsetenv("FACTERTEST");
     value = "";
-    ASSERT_FALSE(environment::get("FACTER_ENV_TEST", value));
+    ASSERT_FALSE(environment::get("FACTERTEST", value));
     ASSERT_EQ("", value);
 }
 
 TEST(facter_util_environment, set) {
-    ASSERT_EQ(nullptr, boost::nowide::getenv("FACTER_ENV_TEST"));
-    ASSERT_TRUE(environment::set("FACTER_ENV_TEST", "FOO"));
-    ASSERT_EQ(string("FOO"), boost::nowide::getenv("FACTER_ENV_TEST"));
-    boost::nowide::unsetenv("FACTER_ENV_TEST");
+    ASSERT_EQ(nullptr, boost::nowide::getenv("FACTERTEST"));
+    ASSERT_TRUE(environment::set("FACTERTEST", "FOO"));
+    ASSERT_EQ(string("FOO"), boost::nowide::getenv("FACTERTEST"));
+    boost::nowide::unsetenv("FACTERTEST");
 }
 
 TEST(facter_util_environment, set_empty) {
-    ASSERT_TRUE(environment::set("FACTER_ENV_TEST", ""));
+    ASSERT_TRUE(environment::set("FACTERTEST", ""));
 
     string value;
-    ASSERT_TRUE(environment::get("FACTER_ENV_TEST", value));
+    ASSERT_TRUE(environment::get("FACTERTEST", value));
     ASSERT_EQ("", value);
 
-    boost::nowide::unsetenv("FACTER_ENV_TEST");
+    boost::nowide::unsetenv("FACTERTEST");
 }
 
 TEST(facter_util_environment, clear) {
-    boost::nowide::setenv("FACTER_ENV_TEST", "FOO", 1);
-    ASSERT_TRUE(environment::clear("FACTER_ENV_TEST"));
-    ASSERT_EQ(nullptr, boost::nowide::getenv("FACTER_ENV_TEST"));
+    boost::nowide::setenv("FACTERTEST", "FOO", 1);
+    ASSERT_TRUE(environment::clear("FACTERTEST"));
+    ASSERT_EQ(nullptr, boost::nowide::getenv("FACTERTEST"));
+}
+
+
+TEST(facter_util_environment, each) {
+    boost::nowide::setenv("FACTERTEST1", "FOO", 1);
+    boost::nowide::setenv("FACTERTEST2", "BAR", 1);
+    boost::nowide::setenv("FACTERTEST3", "BAZ", 1);
+
+    string value1;
+    string value2;
+    string value3;
+    environment::each([&](string& name, string& value) {
+        if (name == "FACTERTEST1") {
+            value1 = move(value);
+        } else if (name == "FACTERTEST2") {
+            value2 = move(value);
+        } else if (name == "FACTERTEST3") {
+            value3 = move(value);
+        }
+        return true;
+    });
+
+    ASSERT_EQ("FOO", value1);
+    ASSERT_EQ("BAR", value2);
+    ASSERT_EQ("BAZ", value3);
+
+    int count_at_stop = 0;
+    int count = 0;
+    environment::each([&](string& name, string& value) {
+        if (name == "FACTERTEST1") {
+            count_at_stop = count;
+            return false;
+        }
+        ++count;
+        return true;
+    });
+    ASSERT_NE(0, count);
+    ASSERT_EQ(count_at_stop, count);
 }


### PR DESCRIPTION
Implementing support for setting fact values from environment variables.

Now users can set variables of the form "FACTER_xyz" and a string fact
will be added.  Environment variable facts are the last source of truth
and can override built-in, external, and custom fact values.

This is supported for backwards compatibility with previous versions of
Facter.
