### PR TITLE
(CFACT-199) Fix build breaks on Windows and Solaris.

### DIFF
--- a/lib/inc/facter/util/environment.hpp
+++ b/lib/inc/facter/util/environment.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+#include <functional>
 
 namespace facter { namespace util {
 

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -15,6 +15,7 @@
 #include <facter/facts/resolvers/ec2_resolver.hpp>
 #include <facter/facts/resolvers/gce_resolver.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
 #include <yaml-cpp/yaml.h>

--- a/lib/src/util/posix/environment.cc
+++ b/lib/src/util/posix/environment.cc
@@ -5,6 +5,9 @@
 
 using namespace std;
 
+// Some platforms need environ explicitly declared
+extern char** environ;
+
 namespace facter { namespace util {
 
     struct search_path_helper

--- a/lib/src/util/windows/environment.cc
+++ b/lib/src/util/windows/environment.cc
@@ -1,6 +1,7 @@
 #include <facter/util/environment.hpp>
 #include <facter/util/windows/windows.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/nowide/convert.hpp>
 #include <functional>
 
 using namespace std;


### PR DESCRIPTION
Build break on Windows: missing include of some headers. Passed Travis because it does a unity build (header dependencies become muddled with unity builds).

Build break on Solaris (and probably OSX): missing declaration of
environ; some platforms don't declare it in unistd.h like they should.