### PR TITLE
(CFACT-204) Fix EC2 instance detection for PV instances.

### DIFF
--- a/lib/inc/facter/http/client.hpp
+++ b/lib/inc/facter/http/client.hpp
@@ -5,13 +5,11 @@
 #pragma once
 
 #include "../util/scoped_resource.hpp"
+#include "request.hpp"
+#include "response.hpp"
 #include <curl/curl.h>
 
 namespace facter { namespace http {
-
-    // Forward declare the request and response
-    struct request;
-    struct response;
 
     /**
      * Resource for a cURL handle.
@@ -76,6 +74,35 @@ namespace facter { namespace http {
             runtime_error(message)
         {
         }
+    };
+
+    /**
+     * The exception for HTTP requests.
+     */
+    struct http_request_exception : http_exception
+    {
+        /**
+         * Constructs an http_request_exception.
+         * @param req The HTTP request that caused the exception.
+         * @param message The exception message.
+         */
+        http_request_exception(request req, std::string const &message) :
+            http_exception(message),
+            _req(std::move(req))
+        {
+        }
+
+        /**
+         * Gets the request associated with the exception
+         * @return Returns the request associated with the exception.
+         */
+        request const& req() const
+        {
+            return _req;
+        }
+
+     private:
+        request _req;
     };
 
     /**
@@ -151,7 +178,7 @@ namespace facter { namespace http {
         };
 
         response perform(http_method method, request const& req);
-        void set_method(http_method method);
+        void set_method(context& ctx, http_method method);
         void set_url(context& ctx);
         void set_headers(context& ctx);
         void set_cookies(context& ctx);

--- a/lib/inc/facter/http/request.hpp
+++ b/lib/inc/facter/http/request.hpp
@@ -22,19 +22,6 @@ namespace facter { namespace http {
         explicit request(std::string url);
 
         /**
-         * Moves the given request into this request.
-         * @param other The request to move into this request.
-         */
-        request(request&& other);
-
-        /**
-         * Moves the given request into this request.
-         * @param other The request to move into this request.
-         * @return Returns this request.
-         */
-        request& operator=(request&& other);
-
-        /**
          * Gets the URL for the request.
          * @return Returns the URL for the request.
          */
@@ -131,9 +118,6 @@ namespace facter { namespace http {
         void connection_timeout(long value);
 
      private:
-        request(request const&) = delete;
-        request& operator=(request const&) = delete;
-
         std::string _url;
         std::string _body;
         long _timeout;

--- a/lib/inc/facter/http/response.hpp
+++ b/lib/inc/facter/http/response.hpp
@@ -15,20 +15,10 @@ namespace facter { namespace http {
      */
     struct response
     {
+        /**
+         * Constructs a HTTP response.
+         */
         response();
-
-        /**
-         * Moves the given response into this response.
-         * @param other The response to move into this response.
-         */
-        response(response&& other);
-
-        /**
-         * Moves the given response into this response.
-         * @param other The response to move into this response.
-         * @return Returns this response.
-         */
-        response& operator=(response&& other);
 
         /**
          * Adds a header to the response.
@@ -81,9 +71,6 @@ namespace facter { namespace http {
         int status_code() const;
 
      private:
-        response(response const&) = delete;
-        response& operator=(response const&) = delete;
-
         int _status_code;
         std::string _body;
         std::map<std::string, std::string> _headers;

--- a/lib/src/http/client.cc
+++ b/lib/src/http/client.cc
@@ -132,11 +132,11 @@ namespace facter { namespace http {
         // Set common options
         auto result = curl_easy_setopt(_handle, CURLOPT_NOPROGRESS, 1);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(req, curl_easy_strerror(result));
         }
         result = curl_easy_setopt(_handle, CURLOPT_FOLLOWLOCATION, 1);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(req, curl_easy_strerror(result));
         }
 
         // Set tracing from libcurl if enabled (we don't care if this fails)
@@ -146,7 +146,7 @@ namespace facter { namespace http {
         }
 
         // Setup the request
-        set_method(method);
+        set_method(ctx, method);
         set_url(ctx);
         set_headers(ctx);
         set_cookies(ctx);
@@ -157,7 +157,7 @@ namespace facter { namespace http {
         // Perform the request
         result = curl_easy_perform(_handle);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(req, curl_easy_strerror(result));
         }
 
         LOG_DEBUG("request completed (status %1%).", res.status_code());
@@ -167,7 +167,7 @@ namespace facter { namespace http {
         return res;
     }
 
-    void client::set_method(http_method method)
+    void client::set_method(context& ctx, http_method method)
     {
         switch (method) {
             case http_method::get:
@@ -177,7 +177,7 @@ namespace facter { namespace http {
             case http_method::post: {
                 auto result = curl_easy_setopt(_handle, CURLOPT_POST, 1);
                 if (result != CURLE_OK) {
-                    throw http_exception(curl_easy_strerror(result));
+                    throw http_request_exception(ctx.req, curl_easy_strerror(result));
                 }
                 break;
             }
@@ -185,13 +185,13 @@ namespace facter { namespace http {
             case http_method::put: {
                 auto result = curl_easy_setopt(_handle, CURLOPT_PUT, 1);
                 if (result != CURLE_OK) {
-                    throw http_exception(curl_easy_strerror(result));
+                    throw http_request_exception(ctx.req, curl_easy_strerror(result));
                 }
                 break;
             }
 
             default:
-                throw http_exception("unexpected HTTP method specified.");
+                throw http_request_exception(ctx.req, "unexpected HTTP method specified.");
         }
     }
 
@@ -200,7 +200,7 @@ namespace facter { namespace http {
         // TODO: support an easy interface for setting escaped query parameters
         auto result = curl_easy_setopt(_handle, CURLOPT_URL, ctx.req.url().c_str());
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
 
         LOG_DEBUG("requesting %1%.", ctx.req.url());
@@ -214,7 +214,7 @@ namespace facter { namespace http {
         });
         auto result = curl_easy_setopt(_handle, CURLOPT_HTTPHEADER, static_cast<curl_slist*>(ctx.request_headers));
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
     }
 
@@ -230,7 +230,7 @@ namespace facter { namespace http {
         });
         auto result = curl_easy_setopt(_handle, CURLOPT_COOKIE, cookies.str().c_str());
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
     }
 
@@ -238,11 +238,11 @@ namespace facter { namespace http {
     {
         auto result = curl_easy_setopt(_handle, CURLOPT_READFUNCTION, read_body);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
         result = curl_easy_setopt(_handle, CURLOPT_READDATA, &ctx);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
     }
 
@@ -250,11 +250,11 @@ namespace facter { namespace http {
     {
         auto result = curl_easy_setopt(_handle, CURLOPT_CONNECTTIMEOUT_MS, ctx.req.connection_timeout());
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
         result = curl_easy_setopt(_handle, CURLOPT_TIMEOUT_MS, ctx.req.timeout());
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
     }
 
@@ -262,19 +262,19 @@ namespace facter { namespace http {
     {
         auto result = curl_easy_setopt(_handle, CURLOPT_HEADERFUNCTION, write_header);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
         result = curl_easy_setopt(_handle, CURLOPT_HEADERDATA, &ctx);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
         result = curl_easy_setopt(_handle, CURLOPT_WRITEFUNCTION, write_body);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
         result = curl_easy_setopt(_handle, CURLOPT_WRITEDATA, &ctx);
         if (result != CURLE_OK) {
-            throw http_exception(curl_easy_strerror(result));
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
     }
 

--- a/lib/src/http/request.cc
+++ b/lib/src/http/request.cc
@@ -11,22 +11,6 @@ namespace facter { namespace http {
     {
     }
 
-    request::request(request&& other)
-    {
-        *this = std::move(other);
-    }
-
-    request& request::operator=(request&& other)
-    {
-        _url = move(other._url);
-        _body = move(other._body);
-        _timeout = other._timeout;
-        _connection_timeout = other._connection_timeout;
-        _headers = move(other._headers);
-        _cookies = move(other._cookies);
-        return *this;
-    }
-
     string const& request::url() const
     {
         return _url;

--- a/lib/src/http/response.cc
+++ b/lib/src/http/response.cc
@@ -9,19 +9,6 @@ namespace facter { namespace http {
     {
     }
 
-    response::response(response&& other)
-    {
-        *this = std::move(other);
-    }
-
-    response& response::operator=(response&& other)
-    {
-        _status_code = other._status_code;
-        _body = move(other._body);
-        _headers = move(other._headers);
-        return *this;
-    }
-
     void response::add_header(string name, string value)
     {
         _headers.emplace(make_pair(move(name), move(value)));


### PR DESCRIPTION
The EC2 fact resolver did a check for "amazon" in the BIOS vendor in an
attempt to prevent an unnecessary network operation when running
under kvm/xen* hypervisors.  However, the BIOS information is only
available to Hardware Virtual Machines (HVM).  For paravirtual (PV)
instances, the BIOS information is unavailable, causing the EC2 resolver
to skip resolving EC2 facts.

As there is no reliable way to detect if we're running under an EC2
instance without querying the metadata endpoint, the fix is to remove
the BIOS vendor check and gracefully handle failing to query the first
endpoint URL.