### PR TITLE
(CFACT-206) Fix crash in JSON output for ruby hash with non-string key.

### DIFF
--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -110,6 +110,10 @@ namespace facter { namespace ruby {
             json.SetObject();
 
             ruby.hash_for_each(value, [&](VALUE key, VALUE element) {
+                // If the key isn't a string, convert to string
+                if (!ruby.is_string(key)) {
+                    key = ruby.rb_funcall(key, ruby.rb_intern("to_s"), 0);
+                }
                 rapidjson::Value e;
                 to_json(ruby, element, allocator, e);
                 json.AddMember(ruby.rb_string_value_ptr(&key), e, allocator);

--- a/lib/tests/fixtures/ruby/hash_with_non_string_key.rb
+++ b/lib/tests/fixtures/ruby/hash_with_non_string_key.rb
@@ -1,0 +1,5 @@
+Facter.add(:foo) do
+  setcode do
+    { foo: 'bar' }
+  end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -329,6 +329,7 @@ vector<ruby_test_parameters> single_fact_tests = {
     ruby_test_parameters("ruby.rb", "ruby", "\"override\""),
     ruby_test_parameters("facterversion.rb", "facterversion", string("\"") + LIBFACTER_VERSION + "\""),
     ruby_test_parameters("ruby.rb", "ruby", "\"from environment!\"", make_pair("FACTER_RuBy", "from environment!")),
+    ruby_test_parameters("hash_with_non_string_key.rb", "foo", "{\n  foo => \"bar\"\n}"),
 };
 
 INSTANTIATE_TEST_CASE_P(run, facter_ruby, testing::ValuesIn(single_fact_tests));


### PR DESCRIPTION
If a custom fact resolution returned a hash with a non-string key
(typically a symbol), then Ruby throws an expcetion from
rb_string_value_ptr because the given VALUE is not a string.

The fix is to properly convert the key to a string like we're already
doing for the other formats.