### PR TITLE
(CFACT-201) Fix custom fact resolution to not preempt built-in values.

### DIFF
--- a/lib/tests/fixtures/ruby/facterversion.rb
+++ b/lib/tests/fixtures/ruby/facterversion.rb
@@ -6,3 +6,12 @@ Facter.add(:facterversion) do
         nil
     end
 end
+
+Facter.add(:facterversion) do
+    setcode do
+        # This tests a custom fact that attempts to override a built-in fact
+        # but does not set a weight higher than 0; the built-in fact should not
+        # be overridden
+        'overridden'
+    end
+end

--- a/lib/tests/fixtures/ruby/ruby.rb
+++ b/lib/tests/fixtures/ruby/ruby.rb
@@ -1,4 +1,5 @@
 Facter.add(:ruby) do
+    has_weight 1
     setcode do
         'override'
     end


### PR DESCRIPTION
Ruby Facter uses the same resolution as the "custom" facts do.  As a
result, custom facts looking to override built-in facts must set an
appropriately high weight on their resolutions to supercede the built-in
resolutions.

Native Facter, instead, was treating the built-in values as a "fallback"
if none of the custom fact resolutions resolved to a value.  As a
result, custom facts could easily override built-in facts without having
to set a higher weight.

This fix first checks to see if the custom facts resolutions all have
weight zero; if so, it first checks the built-in collection for the fact
value.  This forces authors of custom facts to set a weight on their
resolution greater than zero to override a built-in fact.