### PR TITLE
(CFACT-210) build cfacter for fedora 21

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,7 +17,7 @@ gpg_key: '4BD6EC30'
 # Whether to require tarball signing as a prerequisite of other package building
 sign_tar: FALSE
 # a space separated list of mock configs. These are the rpm distributions to package for. If a noarch package, only one arch of each is needed.
-final_mocks: 'pl-el-5-x86_64 pl-el-5-i386 pl-el-6-x86_64 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-20-x86_64'
+final_mocks: 'pl-el-5-x86_64 pl-el-5-i386 pl-el-6-x86_64 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-20-x86_64 pl-fedora-21-i386 pl-fedora-21-x86_64'
 # The host that contains the yum repository to ship to
 yum_host: 'yum.puppetlabs.com'
 # The remote path the repository on the yum\_host


### PR DESCRIPTION
http://builds.delivery.puppetlabs.net/cfacter/1549f785b6a5194976851ca459f07d6f10c57c33/

cfacter on fedora-21-i386
```
[root@ecr00pmcp7bh15f yum.repos.d]# cfacter os
{
  architecture => "i686",
  family => "RedHat",
  hardware => "i386",
  name => "Fedora",
  release => {
    full => "21",
    major => "21"
  }
}
[root@ecr00pmcp7bh15f yum.repos.d]#
```

cfacter on fedora-21-x86_64
```
[root@smgpgjk80b5jqbt yum.repos.d]# cfacter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Fedora",
  release => {
    full => "21",
    major => "21"
  }
}
[root@smgpgjk80b5jqbt yum.repos.d]#
```
