### PR TITLE
(maint) Fix TEMP variable for git.install

### DIFF
--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -8,6 +8,11 @@ param (
 [string] $buildSource=$FALSE
 )
 
+# Ensure TEMP directory is set and exists. Git.install can fail otherwise.
+try { if (!(Test-Path $env:TEMP)) { throw } }
+catch { $env:TEMP = Join-Path $env:SystemDrive 'temp' }
+if (!(Test-Path $env:TEMP)) { mkdir -Path $env:TEMP }
+
 # Starting from a base Windows Server 2008r2 or 2012r2 installation, install required tools, setup the PATH, and download and build software.
 # This script can be run directly from the web using "iex ((new-object net.webclient).DownloadString('<url_to_raw>'))"
 


### PR DESCRIPTION
Git.install fails unless TEMP is set. Ensure temp is set to a directory
that exists in the Windows bootstrap script.