### PR TITLE
(maint) Fix build script parameter types

### DIFF
--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -3,9 +3,9 @@
 # $cores => Set the number of cores to use for parallel builds
 # $buildSource => Choose whether to download pre-built libraries or build from source
 param (
-[string] $arch=64,
-[string] $cores=2,
-[string] $buildSource=$FALSE
+[int] $arch=64,
+[int] $cores=2,
+[bool] $buildSource=$FALSE
 )
 
 # Starting from a base Windows Server 2008r2 or 2012r2 installation, install required tools, setup the PATH, and download and build software.


### PR DESCRIPTION
Fixes the parameter types of the Windows bootstrap script. The
buildSource parameter would always evaluate to true because it's a
string, and strings are always true unless empty.