### PR TITLE
(CFACT-214) Use Myget mirror for Chocolatey pkgs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 install:
   - git submodule update --init --recursive
 
-  - ps: choco install 7zip.commandline
-  - ps: choco install ruby -Version 2.1.5
-  - ps: choco install mingw -Version 4.8.3.20141208
+  - ps: choco install 7zip.commandline -source https://www.myget.org/F/puppetlabs
+  - ps: choco install ruby -Version 2.1.5 -source https://www.myget.org/F/puppetlabs
+  - ps: choco install mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
   - ps: $env:PATH = "C:\tools\ruby215\bin;C:\tools\mingw64\bin;" + $env:PATH
 
   - ps: (New-Object net.webclient).DownloadFile('https://s3.amazonaws.com/kylo-pl-bucket/boost_1_55_0-x86_64_mingw-w64_4.8.3_posix_seh.7z', "$pwd\boost.7z")

--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -26,7 +26,7 @@ echo $buildSource
 
 
 $mingwVerNum = "4.8.3"
-$mingwVerChoco = "${mingwVerNum}.20141208"
+$mingwVerChoco = "${mingwVerNum}"
 $mingwThreads = "win32"
 if ($arch -eq 64) {
   $mingwExceptions = "seh"
@@ -47,17 +47,18 @@ $yamlPkg = "${yamlCppVer}-${mingwVer}"
 ### Setup, build, and install
 ## Install Chocolatey, then use it to install required tools.
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
-choco install 7zip.commandline -Version 9.20.0.20130618
-choco install cmake -Version 3.0.2
-choco install git.install -Version 1.9.5
-choco install python -Version 3.4.2
-choco install doxygen.install -Version 1.8.8
+$plmirror = "https://www.myget.org/F/puppetlabs"
+choco install 7zip.commandline -Version 9.20.0.20150210 -source $plmirror
+choco install cmake -Version 3.0.2.20150210 -source $plmirror
+choco install git.install -Version 1.9.5.20150210 -source $plmirror
+choco install python -Version 3.4.2.20150210 -source $plmirror
+choco install doxygen.install -Version 1.8.9.101 -source $plmirror
 if ($arch -eq 64) {
-  choco install ruby -Version 2.1.5
-  choco install mingw -Version "${mingwVerChoco}" -params "/exception:${mingwExceptions} /threads:${mingwThreads}"
+  choco install ruby -Version 2.1.5.20150210 -source $plmirror
+  choco install mingw-w64 -Version "${mingwVerChoco}" -source $plmirror
 } else {
-  choco install ruby -Version 2.1.5 -x86
-  choco install mingw -Version "${mingwVerChoco}" -params "/exception:${mingwExceptions} /threads:${mingwThreads}" -x86
+  choco install ruby -Version 2.1.5.20150210 -x86 -source $plmirror
+  choco install mingw-w32 -Version "${mingwVerChoco}" -source $plmirror
 }
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 if ($arch -eq 32) {


### PR DESCRIPTION
Use Myget mirror for Chocolatey packages with installers added to the
Nuget packages to avoid dependencies on other external servers (such as
Sourceforge).