### PR TITLE
(CFACT-166) Add Windows Server 2003 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,14 +145,11 @@ if (WIN32)
     # in the same directory to avoid having to setup the DLL search path in the dev environment.
     set(LIBRARY_OUTPUT_PATH    ${PROJECT_BINARY_DIR}/bin)
 
-    # We use networking APIs that require Windows Vista as a minimum. See
-    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx
-    # for version strings.
-    # Supporting Windows Server 2003 requires
-    # - using GetAdaptersInfo to get the network mask and Dhcp server; IPv6 mask may not be supported.
-    # - Use WSA functions for sockaddr to string conversion, which includes more costly WSAStartup.
-    # We currently load IsWow64Process from a DLL, but with these definitions that could be statically linked.
-    add_definitions(-DWINVER=0x0600 -D_WIN32_WINNT=0x0600)
+    # We currently support Windows Server 2003, which requires using deprecated APIs.
+    # See http://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx for version strings.
+    # When Server 2003 support is discontinued, the networking facts implementation can be cleaned up, and
+    # we can statically link symbols that are currently being looked up at runtime.
+    # add_definitions(-DWINVER=0x0600 -D_WIN32_WINNT=0x0600)
 
     # The GetUserNameEx function requires the application have a defined security level.
     # We define security sufficient to get the current user's info.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -121,6 +121,7 @@ if (WIN32)
         "src/util/windows/registry.cc"
         "src/util/windows/system_error.cc"
         "src/util/windows/wmi.cc"
+        "src/util/windows/wsa.cc"
     )
 endif()
 

--- a/lib/inc/facter/facts/windows/networking_resolver.hpp
+++ b/lib/inc/facter/facts/windows/networking_resolver.hpp
@@ -7,6 +7,7 @@
 #include "../resolvers/networking_resolver.hpp"
 #include <vector>
 #include <string>
+#include <functional>
 
 /*
  * Forward declarations from winsock2.h, ws2tcpip.h, windows.h
@@ -24,6 +25,11 @@ namespace facter { namespace facts { namespace windows {
      */
     struct networking_resolver : resolvers::networking_resolver
     {
+        /**
+         * Constructs a Windows networking resolver.
+         */
+        networking_resolver();
+
      protected:
         /**
          * Collects the resolver data.
@@ -53,7 +59,7 @@ namespace facter { namespace facts { namespace windows {
          * @param masklen Length of the contiguous mask.
          * @return The sockaddr_in representation of the mask.
          */
-        static sockaddr_in create_ipv4_mask(uint8_t masklen);
+        sockaddr_in create_ipv4_mask(uint8_t masklen);
 
         /**
          * Creates an IPv6 sockaddr_in6 of the mask. If masklen is too large, returns a full mask.
@@ -61,16 +67,28 @@ namespace facter { namespace facts { namespace windows {
          * @param masklen Length of the contiguous mask.
          * @return The sockaddr_in6 representation of the mask.
          */
-        static sockaddr_in6 create_ipv6_mask(uint8_t masklen);
+        sockaddr_in6 create_ipv6_mask(uint8_t masklen);
 
         /**
-         * Translates a binary address representation to an IPv4 or IPv6 string.
-         * If a mask is specified, applies the mask before translation.
-         * @param addr A SOCKADDR structure defining a valid IPv4 or IPv6 address.
-         * @param mask A SOCKADDR structure defining a valid IPv4 or IPv6 mask.
-         * @return A string representation of the address.
+         * Applies a mask to an IPv4 address, returning a new sockaddr_in.
+         * @param addr A sockaddr structure defining a valid IPv4 address.
+         * @param mask A sockaddr_in structure defining a valid IPv4 mask.
+         * @return A new sockaddr_in structure representing the masked IPv4 address.
          */
-        static std::string address_to_string(sockaddr const* addr, sockaddr const* mask = nullptr);
+        static sockaddr_in mask_ipv4_address(sockaddr const* addr, sockaddr_in const& mask);
+
+        /**
+         * Applies a mask to an IPv6 address, returning a new sockaddr_in6.
+         * @param addr A sockaddr structure defining a valid IPv6 address.
+         * @param mask A sockaddr_in6 structure defining a valid IPv6 mask.
+         * @return A new sockaddr_in6 structure representing the masked IPv6 address.
+         */
+        static sockaddr_in6 mask_ipv6_address(sockaddr const* addr, sockaddr_in6 const& mask);
+
+        /**
+         * Stores a pointer to ConvertLengthToIpv4Mask, which is used post-Windows Server 2003.
+         */
+        std::function<int(unsigned long, unsigned long*)> _convertLengthToIpv4Mask;
     };
 
 }}}  // namespace facter::facts::windows

--- a/lib/inc/facter/util/windows/wsa.hpp
+++ b/lib/inc/facter/util/windows/wsa.hpp
@@ -1,0 +1,98 @@
+/**
+ * @file
+ * Declares utility functions for interacting with Winsock
+ */
+#pragma once
+
+#include <facter/util/windows/windows.hpp>
+#include <string>
+#include <stdexcept>
+
+namespace facter { namespace util { namespace windows {
+
+    /**
+     * Exception thrown when wsa initialization fails.
+     */
+    struct wsa_exception : std::runtime_error
+    {
+        /**
+         * Constructs a wsa_exception.
+         * @param message The exception message.
+         */
+        explicit wsa_exception(std::string const& message);
+    };
+
+    /**
+     * A class for initiating use of the Winsock DLL, providing wrappers for WSA calls.
+     */
+    struct wsa {
+        /**
+         * Initializes Winsock. Throws a wsa_exception on failure.
+         */
+        wsa();
+
+        /**
+         * Do WSA cleanup.
+         */
+        ~wsa();
+
+        /**
+         * Disable copy constructor; there's no reason to make a copy over a new instance.
+         */
+        wsa(wsa const&) = delete;
+
+        /**
+         * Disable copy assignment; there's no reason to make a copy over a new instance.
+         */
+        wsa& operator=(wsa const&) = delete;
+
+        /**
+         * Use default move constructer.
+         */
+        wsa(wsa&&) = default;
+
+        /**
+         * Use default move assignment.
+         */
+        wsa& operator=(wsa&&) = default;
+
+        /**
+         * This wraps calling WSAAddressToString to translate a sockaddr structure to an IPv4 or IPv6 string.
+         * Throws an exception if passed an IPv6 argument on Windows Server 2003 and IPv6 support isn't installed.
+         * See https://social.technet.microsoft.com/Forums/windowsserver/en-US/7166dcbe-d493-4da1-8441-5b5d6aa0d21c/ipv6-and-windows-server-2003
+         * @param addr The socket address structure.
+         * @return An IPv4 or IPv6 string.
+         */
+        std::string saddress_to_string(SOCKET_ADDRESS const& addr) const;
+
+        /**
+         * This adapts sockaddr structs to the SOCKET_ADDRESS wrapper.
+         * @param addr A sockaddr-like structure (sockaddr, sockaddr_in, sockaddr_in6).
+         * @return An IPv4 or IPv6 string.
+         */
+        template<typename T>
+        std::string address_to_string(T &addr) const
+        {
+            return saddress_to_string(SOCKET_ADDRESS{reinterpret_cast<sockaddr *>(&addr), sizeof(T)});
+        }
+
+        /**
+         * This wraps calling WSAStringToAddress to translate a an IPv4 or IPv6 string to a sockaddr structure.
+         * @tparam T The expected sockaddr structure, either sockaddr_in or sockaddr_in6.
+         * @tparam ADDRESS_FAMILY The expected address family, either AF_INET or AF_INET6.
+         * @param addr An IPv4 or IPv6 string.
+         * @return A sockaddr structure containing the IPv4 or IPv6 sockaddr data.
+         */
+        template<typename T, int ADDRESS_FAMILY>
+        T string_to_address(std::string const& addr) const
+        {
+            T sock = {ADDRESS_FAMILY};
+            string_fill_sockaddr(reinterpret_cast<sockaddr*>(&sock), addr, sizeof(T));
+            return sock;
+        }
+
+     private:
+        void string_fill_sockaddr(sockaddr *sock, std::string const& addr, int size) const;
+    };
+
+}}}  // namespace facter::util::windows

--- a/lib/src/facts/windows/networking_resolver.cc
+++ b/lib/src/facts/windows/networking_resolver.cc
@@ -2,6 +2,7 @@
 #include <facter/logging/logging.hpp>
 #include <facter/util/windows/registry.hpp>
 #include <facter/util/windows/system_error.hpp>
+#include <facter/util/windows/wsa.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/range/combine.hpp>
 #include <boost/nowide/convert.hpp>
@@ -15,12 +16,25 @@
   #undef interface
 #endif
 
+#define WIN_SERVER_2003_SUPPORT
+
 using namespace std;
 using namespace facter::util;
 using namespace facter::util::windows;
 using namespace boost::algorithm;
 
 namespace facter { namespace facts { namespace windows {
+
+    networking_resolver::networking_resolver()
+    {
+        // Find ConvertLengthToIpv4Mask and save it to _convertLengthToIpv4Mask. Won't be found on
+        // Windows Server 2003, but in 2003 we get masks as strings so this function isn't needed.
+        auto func = GetProcAddress(GetModuleHandleW(L"Iphlpapi"), "ConvertLengthToIpv4Mask");
+        if (nullptr != func) {
+            typedef int (WINAPI *LPFN_CONVLEN) (ULONG, PULONG);
+            _convertLengthToIpv4Mask = reinterpret_cast<LPFN_CONVLEN>(func);
+        }
+    }
 
     static string get_computername(COMPUTER_NAME_FORMAT nameFormat)
     {
@@ -56,7 +70,7 @@ namespace facter { namespace facts { namespace windows {
     sockaddr_in networking_resolver::create_ipv4_mask(uint8_t masklen)
     {
         sockaddr_in mask = {AF_INET};
-        if (ConvertLengthToIpv4Mask(masklen, &mask.sin_addr.S_un.S_addr) != NO_ERROR) {
+        if (_convertLengthToIpv4Mask && _convertLengthToIpv4Mask(masklen, &mask.sin_addr.S_un.S_addr) != NO_ERROR) {
             LOG_DEBUG("failed creating IPv4 mask of length %1%", masklen);
         }
         return mask;
@@ -67,7 +81,7 @@ namespace facter { namespace facts { namespace windows {
         sockaddr_in6 mask = {AF_INET6};
         const uint8_t incr = 32u;
         for (size_t i = 0; i < 16 && masklen > 0; i += 4, masklen -= min(masklen, incr)) {
-            if (ConvertLengthToIpv4Mask(min(masklen, incr), reinterpret_cast<PULONG>(&mask.sin6_addr.u.Byte[i])) != NO_ERROR) {
+            if (_convertLengthToIpv4Mask && _convertLengthToIpv4Mask(min(masklen, incr), reinterpret_cast<PULONG>(&mask.sin6_addr.u.Byte[i])) != NO_ERROR) {
                 LOG_DEBUG("failed creating IPv6 mask with component of length %1%", incr);
                 break;
             }
@@ -75,42 +89,63 @@ namespace facter { namespace facts { namespace windows {
         return mask;
     }
 
-    string networking_resolver::address_to_string(sockaddr const* addr, sockaddr const* mask)
+    sockaddr_in networking_resolver::mask_ipv4_address(sockaddr const* addr, sockaddr_in const& mask)
     {
-        if (!addr) {
+        sockaddr_in masked = *reinterpret_cast<sockaddr_in const*>(addr);
+        masked.sin_addr.S_un.S_addr &= mask.sin_addr.S_un.S_addr;
+        return masked;
+    }
+
+    sockaddr_in6 networking_resolver::mask_ipv6_address(sockaddr const* addr, sockaddr_in6 const& mask)
+    {
+        sockaddr_in6 masked = *reinterpret_cast<sockaddr_in6 const*>(addr);
+        for (size_t i = 0; i < 8; ++i) {
+            masked.sin6_addr.u.Word[i] &= mask.sin6_addr.u.Word[i];
+        }
+        return masked;
+    }
+
+#ifdef WIN_SERVER_2003_SUPPORT
+    // Provided to get network masks on Windows Server 2003.
+    // Returns a map of IP addresses to their network masks and dhcp servers (if enabled),
+    // obtained using GetAdapterInfo. Only works for IPv4.
+    static map<string, pair<string, string>> legacy_get_masks()
+    {
+        ULONG outBufLen = 15000;
+        vector<char> pAddresses(outBufLen);
+        DWORD err;
+        for (int i = 0; i < 3; ++i) {
+            err = GetAdaptersInfo(reinterpret_cast<PIP_ADAPTER_INFO>(pAddresses.data()), &outBufLen);
+            if (err == ERROR_SUCCESS) {
+                break;
+            } else if (err == ERROR_BUFFER_OVERFLOW) {
+                pAddresses.resize(outBufLen);
+            } else {
+                LOG_DEBUG("failure getting netmask info: %1%", system_error(err));
+                return {};
+            }
+        }
+
+        if (err != ERROR_SUCCESS) {
+            LOG_DEBUG("failure getting netmask info: %1%", system_error(err));
             return {};
         }
 
-        // Check for IPv4 and IPv6
-        if (addr->sa_family == AF_INET) {
-            in_addr ip = reinterpret_cast<sockaddr_in const*>(addr)->sin_addr;
-
-            // Apply an IPv4 mask
-            if (mask && mask->sa_family == addr->sa_family) {
-                ip.S_un.S_addr &= reinterpret_cast<sockaddr_in const*>(mask)->sin_addr.S_un.S_addr;
+        map<string, pair<string, string>> ip_masks;
+        for (auto pCurAddr = reinterpret_cast<PIP_ADAPTER_INFO>(pAddresses.data());
+            pCurAddr; pCurAddr = pCurAddr->Next) {
+            string dhcp;
+            if (pCurAddr->DhcpEnabled) {
+                dhcp = pCurAddr->DhcpServer.IpAddress.String;
             }
-
-            char buffer[INET_ADDRSTRLEN] = {};
-            inet_ntop(AF_INET, &ip, buffer, sizeof(buffer));
-            return buffer;
-        } else if (addr->sa_family == AF_INET6) {
-            in6_addr ip = reinterpret_cast<sockaddr_in6 const*>(addr)->sin6_addr;
-
-            // Apply an IPv6 mask
-            if (mask && mask->sa_family == addr->sa_family) {
-                auto mask_ptr = reinterpret_cast<sockaddr_in6 const*>(mask);
-                for (size_t i = 0; i < 8; ++i) {
-                    ip.u.Word[i] &= mask_ptr->sin6_addr.u.Word[i];
-                }
+            for (auto it = &(pCurAddr->IpAddressList); it; it = it->Next) {
+                ip_masks.insert(make_pair(it->IpAddress.String, make_pair(string(it->IpMask.String), dhcp)));
             }
-
-            char buffer[INET6_ADDRSTRLEN] = {};
-            inet_ntop(AF_INET6, &ip, buffer, sizeof(buffer));
-            return buffer;
         }
-
-        return {};
+        LOG_DEBUG("found %1% netmask entries", ip_masks.size());
+        return ip_masks;
     }
+#endif
 
     networking_resolver::data networking_resolver::collect_data(collection& facts)
     {
@@ -151,6 +186,9 @@ namespace facter { namespace facts { namespace windows {
             return result;
         }
 
+        wsa winsock;
+
+        map<string, pair<string, string>> adapterInfoMasks;
         for (auto pCurAddr = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(pAddresses.data());
             pCurAddr; pCurAddr = pCurAddr->Next) {
             if (pCurAddr->OperStatus != IfOperStatusUp ||
@@ -173,26 +211,75 @@ namespace facter { namespace facts { namespace windows {
                 result.primary_interface = net_interface.name;
             }
 
-            if (pCurAddr->Flags & IP_ADAPTER_DHCP_ENABLED) {
-                net_interface.dhcp_server = address_to_string(pCurAddr->Dhcpv4Server.lpSockaddr);
+            // Only supported on platforms after Windows Server 2003.
+            if (pCurAddr->Flags & IP_ADAPTER_DHCP_ENABLED && pCurAddr->Length >= sizeof(IP_ADAPTER_ADDRESSES_LH)) {
+                auto adapter = reinterpret_cast<IP_ADAPTER_ADDRESSES_LH&>(*pCurAddr);
+                net_interface.dhcp_server = winsock.saddress_to_string(adapter.Dhcpv4Server);
             }
 
             for (auto it = pCurAddr->FirstUnicastAddress; it; it = it->Next) {
-                string addr = address_to_string(it->Address.lpSockaddr);
+                string addr = winsock.saddress_to_string(it->Address);
                 if (addr.empty()) {
                     continue;
                 }
 
+#ifdef WIN_SERVER_2003_SUPPORT
+                // Use length of IP_ADAPTER_ADDRESSES. The length of the unicast address struct doesn't differ between LH and XP
+                // due to padding, so it can't be used.
+                if (pCurAddr->Length < sizeof(IP_ADAPTER_ADDRESSES_LH)) {
+                    if (adapterInfoMasks.empty()) {
+                        adapterInfoMasks = legacy_get_masks();
+                    }
+
+                    // Set the DHCP server on Windows Server 2003.
+                    auto ip_mask = adapterInfoMasks.find(addr);
+                    if (ip_mask != adapterInfoMasks.end()) {
+                        net_interface.dhcp_server = ip_mask->second.second;
+                    }
+                }
+#endif
+
                 if (it->Address.lpSockaddr->sa_family == AF_INET && !ignored_ipv4_address(addr)) {
-                    auto mask = create_ipv4_mask(it->OnLinkPrefixLength);
                     net_interface.address.v4 = move(addr);
-                    net_interface.netmask.v4 = address_to_string(reinterpret_cast<sockaddr *>(&mask));
-                    net_interface.network.v4 = address_to_string(it->Address.lpSockaddr, reinterpret_cast<sockaddr *>(&mask));
+
+                    if (adapterInfoMasks.empty()) {
+                        // Need to do lookup based on the structure length.
+                        auto adapterAddr = reinterpret_cast<IP_ADAPTER_UNICAST_ADDRESS_LH&>(*it);
+                        auto mask = create_ipv4_mask(adapterAddr.OnLinkPrefixLength);
+                        net_interface.netmask.v4 = winsock.address_to_string(mask);
+
+                        auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);
+                        net_interface.network.v4 = winsock.address_to_string(masked);
+                    } else {
+#ifdef WIN_SERVER_2003_SUPPORT
+                        auto ip_mask = adapterInfoMasks.find(net_interface.address.v4);
+                        if (ip_mask != adapterInfoMasks.end()) {
+                            net_interface.netmask.v4 = ip_mask->second.first;
+
+                            auto mask = winsock.string_to_address<sockaddr_in, AF_INET>(ip_mask->second.first);
+                            auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);
+                            net_interface.network.v4 = winsock.address_to_string(masked);
+                        } else {
+                            LOG_DEBUG("could not find netmask for %1%", net_interface.address.v4);
+                        }
+#endif
+                    }
                 } else if (it->Address.lpSockaddr->sa_family == AF_INET6 && !ignored_ipv6_address(addr)) {
-                    auto mask = create_ipv6_mask(it->OnLinkPrefixLength);
                     net_interface.address.v6 = move(addr);
-                    net_interface.netmask.v6 = address_to_string(reinterpret_cast<sockaddr *>(&mask));
-                    net_interface.network.v6 = address_to_string(it->Address.lpSockaddr, reinterpret_cast<sockaddr *>(&mask));
+
+                    // Get mask if on a system later than Windows Server 2003. On 2003, we can't retrieve IPv6 masks.
+                    if (adapterInfoMasks.empty()) {
+                        auto adapterAddr = reinterpret_cast<IP_ADAPTER_UNICAST_ADDRESS_LH&>(*it);
+                        auto mask = create_ipv6_mask(adapterAddr.OnLinkPrefixLength);
+                        net_interface.netmask.v6 = winsock.address_to_string(mask);
+
+                        auto masked = mask_ipv6_address(it->Address.lpSockaddr, mask);
+                        net_interface.network.v6 = winsock.address_to_string(masked);
+                    } else {
+#ifdef WIN_SERVER_2003_SUPPORT
+                        LOG_DEBUG("netmask for %1% (IPv6) is not supported on this platform", net_interface.address.v6);
+#endif
+                    }
                 }
             }
 

--- a/lib/src/util/windows/wsa.cc
+++ b/lib/src/util/windows/wsa.cc
@@ -1,0 +1,60 @@
+#include <facter/util/windows/wsa.hpp>
+#include <facter/logging/logging.hpp>
+#include <boost/nowide/convert.hpp>
+#include <Ws2tcpip.h>
+
+using namespace std;
+
+namespace facter { namespace util { namespace windows {
+
+    wsa_exception::wsa_exception(string const& message) :
+        runtime_error(message)
+    {
+    }
+
+    string format_err(char const* s, int err)
+    {
+        return str(boost::format("%1% (%2%)") % s % boost::io::group(hex, showbase, err));
+    }
+
+    wsa::wsa()
+    {
+        LOG_DEBUG("initializing Winsock");
+        WSADATA wsaData;
+        auto wVersionRequested = MAKEWORD(2, 2);
+        auto err = WSAStartup(wVersionRequested, &wsaData);
+
+        if (err != 0) {
+            throw wsa_exception(format_err("WSAStartup failed with error", err));
+        }
+
+        if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2) {
+            throw wsa_exception("could not find a usable version of Winsock.dll");
+        }
+    }
+
+    wsa::~wsa()
+    {
+        WSACleanup();
+    }
+
+    string wsa::saddress_to_string(SOCKET_ADDRESS const& addr) const
+    {
+        DWORD size = INET6_ADDRSTRLEN;
+        wchar_t buffer[INET6_ADDRSTRLEN];
+        if (0 != WSAAddressToStringW(addr.lpSockaddr, addr.iSockaddrLength, NULL, buffer, &size)) {
+            throw wsa_exception(format_err("address to string translation failed", WSAGetLastError()));
+        }
+
+        return boost::nowide::narrow(buffer);
+    }
+
+    void wsa::string_fill_sockaddr(sockaddr *sock, std::string const& addr, int size) const
+    {
+        auto addrW = boost::nowide::widen(addr);
+        if (0 != WSAStringToAddressW(&addrW[0], sock->sa_family, NULL, sock, &size)) {
+            throw wsa_exception(format_err("string to address translation failed", WSAGetLastError()));
+        }
+    }
+
+}}}  // namespace facter::util::windows


### PR DESCRIPTION
Removes DLL dependencies so it can run on Windows Server 2003, and fixes networking and processor facts.