### PR TITLE
(maint) Config build after nowide install disabled

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -30,7 +30,6 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	$(MAKE) -j$(NUMPROC) install DESTDIR=$(CURDIR)/debian/tmp
-	rm -r $(CURDIR)/debian/tmp$(PREFIX)/include/boost
 
 override_dh_auto_test:
 	$(BUILDPREFIX)/bin/ctest -V

--- a/ext/redhat/cfacter.spec.erb
+++ b/ext/redhat/cfacter.spec.erb
@@ -86,9 +86,6 @@ rm -rf %{buildroot}
 %install
 make %{?_smp_mflags} install DESTDIR=%{buildroot}
 
-# These files are needed at buildtime, but not at runtime
-rm -r %{buildroot}%{_includedir}/boost
-
 %clean
 rm -rf %{buildroot}
 


### PR DESCRIPTION
A previous commit disabled installing Boost.Nowide. Jenkins
configuration specifically removed those files, which is no longer
necessary and causing builds to fail. Remove the redundant Jenkins
config.