### PR TITLE
(CFACT-219) Fix executing external ruby fact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,44 @@
 install:
+  - ps: Get-Date
   - git submodule update --init --recursive
+  - ps: Get-Date
 
   - ps: choco install 7zip.commandline -source https://www.myget.org/F/puppetlabs
   - ps: choco install ruby -Version 2.1.5 -source https://www.myget.org/F/puppetlabs
   - ps: choco install mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
   - ps: $env:PATH = "C:\tools\ruby215\bin;C:\tools\mingw64\bin;" + $env:PATH
+  - ps: Get-Date
 
   - ps: (New-Object net.webclient).DownloadFile('https://s3.amazonaws.com/kylo-pl-bucket/boost_1_55_0-x86_64_mingw-w64_4.8.3_posix_seh.7z', "$pwd\boost.7z")
   - ps: 7za x boost.7z -oC:\tools | FIND /V "ing  "
+  - ps: Get-Date
 
   - ps: (New-Object net.webclient).DownloadFile('https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_posix_seh.7z', "$pwd\yaml-cpp.7z")
   - ps: 7za x yaml-cpp.7z -oC:\tools | FIND /V "ing  "
+  - ps: Get-Date
 
   - ps: (New-Object Net.WebClient).DownloadFile('https://github.com/rubygems/rubygems/releases/download/v2.2.3/rubygems-update-2.2.3.gem', "$pwd\rubygems-update-2.2.3.gem")
   - ps: gem install --local "$pwd\rubygems-update-2.2.3.gem"
   - ps: update_rubygems --no-ri --no-rdoc
+  - ps: Get-Date
 
   - ps: (Get-Content C:\tools\ruby215\lib\ruby\2.1.0\dl.rb) | Foreach-Object {$_ -replace "warn ", "puts "} | Set-Content C:\tools\ruby215\lib\ruby\2.1.0\dl.rb
   - ps: gem install bundler -q --no-ri --no-rdoc
   - ps: bundle install --gemfile=lib/Gemfile --quiet 2>&1 | out-null
+  - ps: Get-Date
 
 build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_55_0-x86_64_mingw-w64_4.8.3_posix_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_posix_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make all_unity
+  - ps: Get-Date
 
 test_script:
   - ps: ctest -V 2>&1 | c++filt
   - ps: mingw32-make install/fast
+  - ps: Get-Date
+
   - ps: $env:PATH += ";C:\Program Files (x86)\CFACTER\bin"
   - ps: cd lib
   - ps: rspec 2>&1 | c++filt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_55_0-x86_64_mingw-w64_4.8.3_posix_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_posix_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
-  - ps: mingw32-make all_unity nowide-static
+  - ps: mingw32-make all_unity
 
 test_script:
   - ps: ctest -V 2>&1 | c++filt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,11 +35,11 @@ build_script:
   - ps: Get-Date
 
 test_script:
-  - ps: ctest -V 2>&1 | c++filt
+  - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }
   - ps: mingw32-make install/fast
   - ps: Get-Date
 
   - ps: $env:PATH += ";C:\Program Files (x86)\CFACTER\bin"
   - ps: cd lib
-  - ps: rspec 2>&1 | c++filt
+  - ps: rspec 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }
   - ps: cd ..

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -30,19 +30,6 @@ namespace facter { namespace execution {
 
     struct extpath_helper
     {
-        extpath_helper()
-        {
-            // Enforce lower-case operations to ignore case.
-            string extpaths;
-            if (environment::get("PATHEXT", extpaths)) {
-                boost::split(_extpaths, extpaths, bind(equal_to<char>(), placeholders::_1, environment::get_path_separator()), boost::token_compress_on);
-            } else {
-                _extpaths = {".bat", ".cmd", ".com", ".exe"};
-            }
-            sort(_extpaths.begin(), _extpaths.end());
-            for_each(_extpaths.begin(), _extpaths.end(), [](string &s) { to_lower(s); });
-        }
-
         vector<string> const& ext_paths() const
         {
             return _extpaths;
@@ -54,7 +41,8 @@ namespace facter { namespace execution {
         }
 
      private:
-         vector<string> _extpaths;
+        // Use sorted, lower-case operations to ignore case and use binary search.
+        vector<string> _extpaths = {".bat", ".cmd", ".com", ".exe"};;
     };
 
     static bool is_executable(path const& p, extpath_helper const* helper = nullptr)

--- a/lib/tests/facts/external/windows/execution_resolver.cc
+++ b/lib/tests/facts/external/windows/execution_resolver.cc
@@ -18,6 +18,7 @@ TEST(facter_facts_external_windows_execution_resolver, default_constructor) {
 TEST(facter_facts_external_windows_execution_resolver, can_resolve) {
     execution_resolver resolver;
     ASSERT_FALSE(resolver.can_resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution/not_executable"));
+    ASSERT_FALSE(resolver.can_resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution/ruby_script.rb"));
     ASSERT_TRUE(resolver.can_resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution/facts.bat"));
 }
 

--- a/lib/tests/facts/windows/collection.cc
+++ b/lib/tests/facts/windows/collection.cc
@@ -31,7 +31,7 @@ TEST(facter_facts_windows_collection, resolve_external) {
     ASSERT_NE(nullptr, facts.get<string_value>("ps1_fact4"));
 }
 
-TEST(facter_facts_posix_collection, resolve_external_relative) {
+TEST(facter_facts_windows_collection, resolve_external_relative) {
     test_with_relative_path fixture("foo.bat", "@echo local_exec_fact=value");
 
     collection facts;

--- a/lib/tests/fixtures/facts/external/windows/execution/ruby_script.rb
+++ b/lib/tests/fixtures/facts/external/windows/execution/ruby_script.rb
@@ -1,0 +1,1 @@
+puts "rbver=#{RUBY_VERSION}"


### PR DESCRIPTION
A Ruby script can be used as an external fact. On Windows, that doesn't
work if you try to invoke the script using CreateProcess; an execution
environment that knows about Ruby is required. Wraps external facts in a
shell to ensure scripts are run in a usable environment.