### PR TITLE
(CFACT-220) Write git describe to VERSION

### DIFF
--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -149,5 +149,8 @@ $args = @(
 cmake $args
 mingw32-make -j $cores
 
+## Write out the version that was just built.
+git describe --long > bin/VERSION
+
 ## Test the results.
 ctest -V 2>&1 | c++filt


### PR DESCRIPTION
Writes git describe --long to a bin/VERSION file during Windows builds for
packaging to pick up. Put into bin to simplify packaging pipeline
changes.