### PR TITLE
(CFACT-221) Build cfacter for stable

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -5,7 +5,7 @@ deb_build_mirrors:
   - deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main
 default_cow: 'base-wheezy-i386.cow'
 # Which debian distributions to build for. Noarch packages only need one arch of each cow.
-cows: 'base-lucid-amd64.cow base-lucid-i386.cow base-precise-amd64.cow base-precise-i386.cow base-squeeze-amd64.cow base-squeeze-i386.cow base-trusty-amd64.cow base-trusty-i386.cow base-wheezy-amd64.cow base-wheezy-i386.cow'
+cows: 'base-lucid-amd64.cow base-lucid-i386.cow base-precise-amd64.cow base-precise-i386.cow base-squeeze-amd64.cow base-squeeze-i386.cow base-stable-amd64.cow base-stable-i386.cow base-trusty-amd64.cow base-trusty-i386.cow base-wheezy-amd64.cow base-wheezy-i386.cow'
 # The pbuilder configuration file to use
 pbuild_conf: '/etc/pbuilderrc'
 # Who is packaging. Turns up in various packaging artifacts


### PR DESCRIPTION
This commit adds Debian stable-amd64 and stable-i386 as build targets
for cfacter.

http://builds.delivery.puppetlabs.net/cfacter/37b60cb7e2c56e8b96b4901b2feb358aec2a1d4d/

cfacter on stable-i386
```
root@qqg8fpknelwty4z:/etc/apt/sources.list.d# cfacter os
{
  architecture => "i686",
  distro => {
    codename => "wheezy",
    description => "Debian GNU/Linux 7.4 (wheezy)",
    id => "Debian",
    release => {
      full => "7.4",
      major => "7",
      minor => "4"
    }
  },
  family => "Debian",
  hardware => "i386",
  name => "Debian",
  release => {
    full => "7.4",
    major => "7",
    minor => "4"
  }
}
```

cfacter on stable-amd64
```
root@o3fpvj26vcgr6uj:/etc/apt/sources.list.d# cfacter os
{
  architecture => "x86_64",
  distro => {
    codename => "wheezy",
    description => "Debian GNU/Linux 7.4 (wheezy)",
    id => "Debian",
    release => {
      full => "7.4",
      major => "7",
      minor => "4"
    }
  },
  family => "Debian",
  hardware => "x86_64",
  name => "Debian",
  release => {
    full => "7.4",
    major => "7",
    minor => "4"
  }
}
```
