### PR TITLE
(CFACT-215) use /etc/os-release to identify CoreOS

### DIFF
--- a/lib/inc/facter/facts/linux/operating_system_resolver.hpp
+++ b/lib/inc/facter/facts/linux/operating_system_resolver.hpp
@@ -32,7 +32,7 @@ namespace facter { namespace facts { namespace linux {
      private:
         static std::string get_name(std::string const& distro_id);
         static std::string get_release(std::string const& name, std::string const& distro_release);
-        static std::string check_cumulus_linux();
+        static std::string check_os_release_linux();
         static std::string check_debian_linux(std::string const& distro_id);
         static std::string check_oracle_linux();
         static std::string check_redhat_linux();

--- a/lib/inc/facter/facts/linux/release_file.hpp
+++ b/lib/inc/facter/facts/linux/release_file.hpp
@@ -49,6 +49,9 @@ namespace facter { namespace facts { namespace linux {
         constexpr static char const* suse = "/etc/SuSE-release";
         /**
          * Release file for generic Linux distros.
+         * Also used for:
+         * - CoreOS
+         * - Cumulus
          */
         constexpr static char const* os = "/etc/os-release";
         /**

--- a/lib/inc/facter/facts/os.hpp
+++ b/lib/inc/facter/facts/os.hpp
@@ -156,6 +156,10 @@ namespace facter { namespace facts {
          */
         constexpr static char const* alpine = "Alpine";
         /**
+         * The CoreOS Linux operating system.
+         */
+        constexpr static char const* coreos = "CoreOS";
+        /**
          * The Cumulus Linux operating system.
          */
         constexpr static char const* cumulus = "CumulusLinux";

--- a/lib/inc/facter/facts/os_family.hpp
+++ b/lib/inc/facter/facts/os_family.hpp
@@ -16,6 +16,10 @@ namespace facter { namespace facts {
          */
         constexpr static char const* redhat = "RedHat";
         /**
+         * The CoreOS family of operating systems.
+         */
+        constexpr static char const* coreos = "CoreOS";
+        /**
          * The Debian family of operating systems.
          */
         constexpr static char const* debian = "Debian";

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -220,6 +220,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
         if (!name.empty()) {
             static map<string, string> const systems = {
+                { string(os::coreos),                   string(os_family::coreos) },
                 { string(os::redhat),                   string(os_family::redhat) },
                 { string(os::fedora),                   string(os_family::redhat) },
                 { string(os::centos),                   string(os_family::redhat) },


### PR DESCRIPTION
This commit ports https://github.com/puppetlabs/facter/pull/845
to native facter.