### PR TITLE
(CFACT-74) Allow compile-time setting libruby loc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ if (FACTER_PATH)
     message(STATUS "Prioritizing binary lookup in ${FACTER_PATH_FIXED}")
 endif()
 
+set(FACTER_RUBY "" CACHE FILEPATH "Specify the location of libruby at compile-time, bypassing dynamic lookup.")
+if (FACTER_RUBY)
+    file(TO_CMAKE_PATH ${FACTER_RUBY} FACTER_RUBY_PATH)
+    add_definitions(-DFACTER_RUBY="${FACTER_RUBY_PATH}")
+    message(STATUS "Fixing lookup for libruby to ${FACTERPATH_PATH}")
+endif()
+
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/lib/src/ruby/posix/api.cc
+++ b/lib/src/ruby/posix/api.cc
@@ -22,6 +22,13 @@ namespace facter { namespace ruby {
             return library;
         }
 
+#ifdef FACTER_RUBY
+        // Ruby lib location was specified at compile-time, fix to that.
+        if (!library.load(FACTER_RUBY)) {
+            LOG_WARNING("ruby library \"%1%\" could not be loaded.", FACTER_RUBY);
+        }
+        return library;
+#else
         // Next try an environment variable
         // This allows users to directly specify the ruby version to use
         string value;
@@ -127,6 +134,7 @@ namespace facter { namespace ruby {
             library.load(libruby);
         }
         return library;
+#endif
     }
 
 }}  // namespace facter::ruby

--- a/lib/src/ruby/windows/api.cc
+++ b/lib/src/ruby/windows/api.cc
@@ -22,6 +22,14 @@ namespace facter { namespace ruby {
             return library;
         }
 
+#ifdef FACTER_RUBY
+        // Ruby lib location was specified at compile-time, fix to that.
+        if (!library.load(FACTER_RUBY)) {
+            LOG_WARNING("ruby library \"%1%\" could not be loaded.", FACTER_RUBY);
+        }
+        return library;
+#else
+
         // 2. Check the FACTERRUBY environment variable
         string value;
         if (environment::get("FACTERRUBY", value)) {
@@ -83,6 +91,7 @@ namespace facter { namespace ruby {
             LOG_DEBUG("ruby could not be found on the PATH.");
         }
         return library;
+#endif
     }
 
 }}  // namespace facter::ruby


### PR DESCRIPTION
Allow libruby location to be set at compile-time, so we can specify
which Ruby should be used as part of a package (AIO).