### PR TITLE
(CFACT-220) cfacter.ps1 VERSION file in ASCII

### DIFF
--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -167,7 +167,7 @@ cmake $args
 mingw32-make -j $cores
 
 ## Write out the version that was just built.
-git describe --long > bin/VERSION
+git describe --long | Out-File -FilePath 'bin/VERSION' -Encoding ASCII -Force
 
 ## Test the results.
 ctest -V 2>&1 | c++filt


### PR DESCRIPTION
 - Previously, the output of `git describe` was written directly to
   `bin/VERSION`.  Unfortunately, this was resulting in a UCS-2 file
   with a BOM that our Ruby 1.8 based build environment could not easily
   parse.

   To make life easier, capture the command output in PowerShell, and
   use the Out-File cmdlet to force an ASCII file be written instead.
   Consumers of this file will no longer need to jump through hoops.

   Verified in both Ruby 1.8.7 and Ruby 2.1.5 that File.read('VERSION')
   will properly return this results of this file.