### PR TITLE
(CFACT-217) Exit with a failure code when an error has been logged

### DIFF
--- a/exe/cfacter.cc
+++ b/exe/cfacter.cc
@@ -263,10 +263,9 @@ int main(int argc, char **argv)
         }
         facts.write(boost::nowide::cout, fmt, queries);
         boost::nowide::cout << endl;
-
-        return EXIT_SUCCESS;
     } catch (exception& ex) {
         LOG_FATAL("unhandled exception: %1%", ex.what());
-        return EXIT_FAILURE;
     }
+
+    return error_has_been_logged() ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/lib/inc/facter/logging/logging.hpp
+++ b/lib/inc/facter/logging/logging.hpp
@@ -190,6 +190,19 @@ namespace facter { namespace logging {
     bool is_enabled(log_level level);
 
     /**
+     * Determine if an error has been logged
+     * @return Returns true if an error or critical message has been logged
+     */
+    bool error_has_been_logged();
+
+    /**
+     * Clear the flag that indicates an error has been logged.
+     * This is necessary for testing the flagging functionality. This function should
+     * not be used by library consumers.
+     */
+    void clear_error_logged_flag();
+
+    /**
      * Logs a given message to the given logger.
      * @param logger The logger to log the message to.
      * @param level The logging level to log with.

--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -32,6 +32,7 @@ namespace facter { namespace logging {
     static function<bool(log_level, string const&)> g_callback;
     static log_level g_level = log_level::none;
     static bool g_colorize = false;
+    static bool g_error_logged = false;
 
     void setup_logging(ostream &dst)
     {
@@ -91,6 +92,14 @@ namespace facter { namespace logging {
         return g_level != log_level::none && static_cast<int>(level) >= static_cast<int>(g_level);
     }
 
+    bool error_has_been_logged() {
+        return g_error_logged;
+    }
+
+    void clear_error_logged_flag() {
+        g_error_logged = false;
+    }
+
     void on_message(function<bool(log_level, string const&)> callback)
     {
         g_callback = callback;
@@ -134,6 +143,9 @@ namespace facter { namespace logging {
 
     void log(const string &logger, log_level level, string const& message)
     {
+        if (level >= log_level::error) {
+            g_error_logged = true;
+        }
         if (!is_enabled(level) || (g_callback && !g_callback(level, message))) {
             return;
         }

--- a/lib/tests/logging/logging.cc
+++ b/lib/tests/logging/logging.cc
@@ -31,6 +31,8 @@ struct logging_test_context
     logging_test_context()
     {
         set_level(log_level::trace);
+        clear_error_logged_flag();
+
         _appender.reset(new custom_log_appender());
         _sink.reset(new sink_t(_appender));
 
@@ -42,6 +44,7 @@ struct logging_test_context
     {
         set_level(log_level::none);
         on_message(nullptr);
+        clear_error_logged_flag();
 
         auto core = boost::log::core::get();
         core->reset_filter();
@@ -64,6 +67,7 @@ SCENARIO("logging with a TRACE level") {
     log("test", log_level::trace, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "TRACE");
     REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + "testing 1 2 3" + colorize());
+    REQUIRE_FALSE(error_has_been_logged());
 }
 
 SCENARIO("logging with a DEBUG level") {
@@ -75,6 +79,7 @@ SCENARIO("logging with a DEBUG level") {
     log("test", log_level::debug, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "DEBUG");
     REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + "testing 1 2 3" + colorize());
+    REQUIRE_FALSE(error_has_been_logged());
 }
 
 SCENARIO("logging with an INFO level") {
@@ -86,6 +91,7 @@ SCENARIO("logging with an INFO level") {
     log("test", log_level::info, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "INFO");
     REQUIRE(context._appender->_message == string(colorize(log_level::info)) + "testing 1 2 3" + colorize());
+    REQUIRE_FALSE(error_has_been_logged());
 }
 
 SCENARIO("logging with a WARNING level") {
@@ -97,6 +103,7 @@ SCENARIO("logging with a WARNING level") {
     log("test", log_level::warning, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "WARN");
     REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + "testing 1 2 3" + colorize());
+    REQUIRE_FALSE(error_has_been_logged());
 }
 
 SCENARIO("logging with an ERROR level") {
@@ -108,6 +115,7 @@ SCENARIO("logging with an ERROR level") {
     log("test", log_level::error, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "ERROR");
     REQUIRE(context._appender->_message == string(colorize(log_level::error)) + "testing 1 2 3" + colorize());
+    REQUIRE(error_has_been_logged());
 }
 
 SCENARIO("logging with a FATAL level") {
@@ -119,6 +127,7 @@ SCENARIO("logging with a FATAL level") {
     log("test", log_level::fatal, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "FATAL");
     REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + "testing 1 2 3" + colorize());
+    REQUIRE(error_has_been_logged());
 }
 
 SCENARIO("logging with on_message") {


### PR DESCRIPTION
Previously, cfacter would only exit with a failure code if an
exception managed to bubble all the way up to main. This meant that it
was impossible to tell without parsing the log output whether an error
had actually been encountered.

This adds functionality to the logger to track when an error or fatal
message is logged, and updates the cfacter main to use this
functionality to return a failure code when such a message has been
loged.