### PR TITLE
(CFACT-126) Rename 'productuuid' top level flat fact to 'uuid'

### DIFF
--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -225,7 +225,7 @@ namespace facter { namespace facts {
         /**
          * The fact for hardware UUID.
          */
-        constexpr static char const* product_uuid = "productuuid";
+        constexpr static char const* uuid = "uuid";
         /**
          * The fact for hardware chassis type.
          */

--- a/lib/inc/facter/facts/resolvers/dmi_resolver.hpp
+++ b/lib/inc/facter/facts/resolvers/dmi_resolver.hpp
@@ -96,7 +96,7 @@ namespace facter { namespace facts { namespace resolvers {
             /**
              * Stores the system product UUID.
              */
-            std::string product_uuid;
+            std::string uuid;
 
             /**
              * Stores the system chassis type.

--- a/lib/src/facts/linux/dmi_resolver.cc
+++ b/lib/src/facts/linux/dmi_resolver.cc
@@ -25,7 +25,7 @@ namespace facter { namespace facts { namespace linux {
         result.manufacturer         = read("/sys/class/dmi/id/sys_vendor");
         result.product_name         = read("/sys/class/dmi/id/product_name");
         result.serial_number        = read("/sys/class/dmi/id/product_serial");
-        result.product_uuid         = read("/sys/class/dmi/id/product_uuid");
+        result.uuid                 = read("/sys/class/dmi/id/product_uuid");
         result.chassis_type         = to_chassis_description(read("/sys/class/dmi/id/chassis_type"));
         return result;
     }

--- a/lib/src/facts/resolvers/dmi_resolver.cc
+++ b/lib/src/facts/resolvers/dmi_resolver.cc
@@ -24,7 +24,7 @@ namespace facter { namespace facts { namespace resolvers {
                 fact::manufacturer,
                 fact::product_name,
                 fact::serial_number,
-                fact::product_uuid,
+                fact::uuid,
                 fact::chassis_type,
             })
     {
@@ -116,9 +116,9 @@ namespace facter { namespace facts { namespace resolvers {
             facts.add(fact::serial_number, make_value<string_value>(data.serial_number, true));
             product->add("serial_number", make_value<string_value>(move(data.serial_number)));
         }
-        if (!data.product_uuid.empty()) {
-            facts.add(fact::product_uuid, make_value<string_value>(data.product_uuid, true));
-            product->add("uuid", make_value<string_value>(move(data.product_uuid)));
+        if (!data.uuid.empty()) {
+            facts.add(fact::uuid, make_value<string_value>(data.uuid, true));
+            product->add("uuid", make_value<string_value>(move(data.uuid)));
         }
 
         auto chassis = make_value<map_value>();

--- a/lib/src/facts/solaris/dmi_resolver.cc
+++ b/lib/src/facts/solaris/dmi_resolver.cc
@@ -44,13 +44,13 @@ namespace facter { namespace facts { namespace solaris {
                 if (result.product_name.empty()) {
                     re_search(line, product_re, &result.product_name);
                 }
-                if (result.product_uuid.empty()) {
-                    re_search(line, uuid_re, &result.product_uuid);
+                if (result.uuid.empty()) {
+                    re_search(line, uuid_re, &result.uuid);
                 }
                 if (result.serial_number.empty()) {
                     re_search(line, serial_re, &result.serial_number);
                 }
-                return result.manufacturer.empty() || result.product_name.empty() || result.product_uuid.empty() || result.serial_number.empty();
+                return result.manufacturer.empty() || result.product_name.empty() || result.uuid.empty() || result.serial_number.empty();
             });
 
             re_adapter chassis_type_re("(?:Chassis )?Type: (.+)");

--- a/lib/tests/facts/resolvers/dmi_resolver.cc
+++ b/lib/tests/facts/resolvers/dmi_resolver.cc
@@ -35,7 +35,7 @@ struct test_dmi_resolver : dmi_resolver
         result.manufacturer = fact::manufacturer;
         result.product_name = fact::product_name;
         result.serial_number = fact::serial_number;
-        result.product_uuid = fact::product_uuid;
+        result.uuid = fact::uuid;
         result.chassis_type = fact::chassis_type;
         return result;
     }
@@ -122,7 +122,7 @@ SCENARIO("using the DMI resolver") {
 
             value = product->get<string_value>("uuid");
             REQUIRE(value);
-            REQUIRE(value->value() == string(fact::product_uuid));
+            REQUIRE(value->value() == string(fact::uuid));
         }
         THEN("flat facts are added") {
             static vector<string> const names = {
@@ -137,7 +137,7 @@ SCENARIO("using the DMI resolver") {
                 fact::manufacturer,
                 fact::product_name,
                 fact::serial_number,
-                fact::product_uuid,
+                fact::uuid,
                 fact::chassis_type,
             };
             for (auto const& name : names) {


### PR DESCRIPTION
In native Facter, the former 'uuid' top-level fact was renamed to 'productuuid.'
To maintain backwards compatibility, this commit reverts that change so
that 'uuid' is once again the top-level fact name.

Note that top-level flat facts are now considered legacy facts, since the
default output of native facter is fully structured. This change does
not affect the 'dmi' structured fact, or the 'dmi.product.uuid' fact
within it. It can only be accessed directly by invoking cfacter with
'uuid' as an argument.