### PR TITLE
(CFACT-228) Update default path for external facts.

### DIFF
--- a/lib/src/facts/posix/collection.cc
+++ b/lib/src/facts/posix/collection.cc
@@ -25,7 +25,7 @@ namespace facter { namespace facts {
                 directories.emplace_back(home + "/.facter/facts.d");
             }
         } else {
-            directories.emplace_back("/opt/puppetlabs/agent/facts.d");
+            directories.emplace_back("/opt/puppetlabs/facter/facts.d");
         }
         return directories;
     }


### PR DESCRIPTION
Updating the default path for external facts from
/opt/puppetlabs/agent/facts.d to /opt/puppetlabs/facter/facts.d per
recent AIO changes.