### PR TITLE
(CFACT-230) Fix architecture fact resolution on certain Linux distros.

### DIFF
--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -26,23 +26,6 @@ namespace facter { namespace facts { namespace linux {
         // Default to the base implementation
         data result = posix::operating_system_resolver::collect_data(facts);
 
-        // Convert the hardware model value depending on distro
-        // For certain distros, use "amd64" for x86_64
-        if (result.hardware == "x86_64" && (
-             result.name == os::debian ||
-             result.name == os::gentoo ||
-             result.name == os::kfreebsd ||
-             result.name == os::ubuntu)) {
-            result.hardware = "amd64";
-        } else if (re_search(result.hardware, "i[3456]86|pentium")) {
-            // For 32-bit, use "x86" for Gentoo and "i386" for everyone else
-            if (result.name == os::gentoo) {
-                result.hardware = "x86";
-            } else {
-                result.hardware = "i386";
-            }
-        }
-
         // Populate distro info
         execution::each_line("lsb_release", {"-a"}, [&](string& line) {
             string* variable = nullptr;
@@ -79,6 +62,24 @@ namespace facter { namespace facts { namespace linux {
         auto release = get_release(result.name, result.distro.release);
         if (!release.empty()) {
             result.release = move(release);
+        }
+
+        // Convert the architecture value depending on distro
+        // For certain distros, use "amd64" for "x86_64"
+        // For certain distros, use "x86" for "i386"
+        if (result.architecture == "x86_64" && (
+             result.name == os::debian ||
+             result.name == os::gentoo ||
+             result.name == os::kfreebsd ||
+             result.name == os::ubuntu)) {
+            result.architecture = "amd64";
+        } else if (re_search(result.architecture, "i[3456]86|pentium")) {
+            // For 32-bit, use "x86" for Gentoo and "i386" for everyone else
+            if (result.name == os::gentoo) {
+                result.architecture = "x86";
+            } else {
+                result.architecture = "i386";
+            }
         }
 
         return result;


### PR DESCRIPTION
On Debian, Gentoo, kFreeBSD, and Gentoo, the architecture fact should
resolve to "amd64" for "x86_64".  On Gentoo, it should resolve to "x86"
for "i386".  However, the code was attempting to resolve the
hardwaremodel fact to these values instead.  Additionally, the check for
the distro name occurs before it was being populated.

The fix is to move the check to after the distro name is being resolved
and change the assignment to the architecture fact.