### PR TITLE
(CFACT-231) Resolve processors.isa and hardwareisa in Windows

### DIFF
--- a/lib/inc/facter/util/windows/wmi.hpp
+++ b/lib/inc/facter/util/windows/wmi.hpp
@@ -60,6 +60,11 @@ namespace facter { namespace util { namespace windows {
         constexpr static char const* processor = "Win32_Processor";
 
         /**
+         * Identifier for the WMI property Architecture
+         */
+        constexpr static char const* architecture = "Architecture";
+
+        /**
          * Identifier for the WMI property Name
          */
         constexpr static char const* name = "Name";

--- a/lib/src/facts/windows/processor_resolver.cc
+++ b/lib/src/facts/windows/processor_resolver.cc
@@ -1,6 +1,7 @@
 #include <facter/facts/windows/processor_resolver.hpp>
 #include <facter/util/windows/wmi.hpp>
 #include <facter/util/regex.hpp>
+#include <facter/logging/logging.hpp>
 
 using namespace std;
 using namespace facter::util;
@@ -14,10 +15,11 @@ namespace facter { namespace facts { namespace windows {
     {
     }
 
-    // Returns physical_count, logical_count, models, speed
-    static tuple<int, int, vector<string>, int64_t> get_processors(wmi const& _wmi)
+    // Returns physical_count, logical_count, models, isa, speed
+    static tuple<int, int, vector<string>, string, int64_t> get_processors(wmi const& _wmi)
     {
         vector<string> models;
+        string isa;
         int logical_count = 0;
 
         auto names = _wmi.query(wmi::processor, {wmi::name});
@@ -36,13 +38,52 @@ namespace facter { namespace facts { namespace windows {
             logical_count = models.size();
         }
 
-        return make_tuple(models.size(), logical_count, move(models), 0);
+        // Query for architecture and transform numerical ID into a string based on
+        // https://msdn.microsoft.com/en-us/library/aa394373%28v=vs.85%29.aspx.
+        // Use the architecture of the first result.
+        auto arch_id = _wmi.query(wmi::processor, {wmi::architecture});
+        if (!arch_id.empty()) {
+            int architecture = stoi(wmi::get(arch_id.front(), wmi::architecture));
+
+            switch (architecture) {
+                case 0:
+                    isa = "x86";
+                    break;
+                case 1:
+                    isa = "MIPS";
+                    break;
+                case 2:
+                    isa = "Alpha";
+                    break;
+                case 3:
+                    isa = "PowerPC";
+                    break;
+                case 5:
+                    isa = "ARM";
+                    break;
+                case 6:
+                    isa = "Itanium-based systems";
+                    break;
+                case 9:
+                    isa = "x64";
+                    break;
+                default:
+                    LOG_DEBUG("Unable to determine processor type: unknown architecture");
+                    isa = "";
+                    break;
+            }
+        } else {
+            LOG_DEBUG("WMI processor Architecture query returned no results.");
+            isa = "";
+        }
+
+        return make_tuple(models.size(), logical_count, move(models), move(isa), 0);
     }
 
     processor_resolver::data processor_resolver::collect_data(collection& facts)
     {
         data result;
-        tie(result.physical_count, result.logical_count, result.models, result.speed) = get_processors(*_wmi);
+        tie(result.physical_count, result.logical_count, result.models, result.isa, result.speed) = get_processors(*_wmi);
         return result;
     }
 


### PR DESCRIPTION
Prior to this commit, the processors.isa and hardwareisa facts were
not being populated in Windows.

This commit adds the necessary logic to query WMI for "Architecture"
and transform the returned numerical ID into a string representing the
processor type.

Details on the translation from ID to processor type can be found here:
https://msdn.microsoft.com/en-us/library/aa394373%28v=vs.85%29.aspx