### PR TITLE
(CFACT-158) Add script to generate fact documentation markdown.

### DIFF
--- a/lib/docs/generate.rb
+++ b/lib/docs/generate.rb
@@ -1,0 +1,12 @@
+require 'yaml'
+require 'erb'
+require 'ostruct'
+
+PATH_TO_SCHEMA = File.join(File.dirname(__FILE__), '../schema/facter.yaml')
+PATH_TO_TEMPLATE = File.join(File.dirname(__FILE__), 'template.erb')
+
+scope = OpenStruct.new({
+  :facts => YAML.load_file(PATH_TO_SCHEMA)
+})
+
+puts ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-').result(scope.instance_eval {binding})

--- a/lib/docs/template.erb
+++ b/lib/docs/template.erb
@@ -1,0 +1,22 @@
+<%# This template is used to generate a markdown file documenting facts. -%>
+<%# Run 'ruby generate.rb > facts.md' to generate the markdown file. -%>
+<% facts.each do |name, schema| -%>
+## `<%= name %>`
+
+**Purpose:**
+
+<%= schema['description'] %>
+<% if schema['resolution'] %>
+**Resolution:**
+
+<%= schema['resolution'].split("\n").map { |line| "* " + line }.join("\n") %>
+<% end -%>
+<% if schema['caveats'] %>
+**Caveats:**
+
+<%= schema['caveats'].split("\n").map { |line| "* " + line }.join("\n") %>
+<% end -%>
+
+([↑ Back to top](#page-nav))
+
+<% end -%>


### PR DESCRIPTION
Adding lib/docs/generate.rb (usage: ruby generate.rb > facts.md).
This script will transform the schema file into a markdown and extract
the name, purpose, resolutions, and caveats for each fact.