### PR TITLE
(CFACT-152) Add script to generate fact documentation markdown.

### DIFF
--- a/lib/docs/generate.rb
+++ b/lib/docs/generate.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# Generates a markdown file containing fact documentation.
+# usage: ruby generate.rb > facts.md
+
+require 'yaml'
+require 'erb'
+require 'ostruct'
+
+PATH_TO_SCHEMA = File.join(File.dirname(__FILE__), '../schema/facter.yaml')
+PATH_TO_TEMPLATE = File.join(File.dirname(__FILE__), 'template.erb')
+
+scope = OpenStruct.new({
+  :facts => YAML.load_file(PATH_TO_SCHEMA)
+})
+
+puts ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-').result(scope.instance_eval {binding})

--- a/lib/docs/template.erb
+++ b/lib/docs/template.erb
@@ -1,0 +1,22 @@
+<%# This template is used to generate a markdown file documenting facts. -%>
+<%# Run 'ruby generate.rb > facts.md' to generate the markdown file. -%>
+<% facts.each do |name, schema| -%>
+## `<%= name %>`
+
+**Purpose:**
+
+<%= schema['description'] %>
+<% if schema['resolution'] %>
+**Resolution:**
+
+<%= schema['resolution'].split("\n").map { |line| "* " + line }.join("\n") %>
+<% end -%>
+<% if schema['caveats'] %>
+**Caveats:**
+
+<%= schema['caveats'].split("\n").map { |line| "* " + line }.join("\n") %>
+<% end -%>
+
+([↑ Back to top](#page-nav))
+
+<% end -%>

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -44,6 +44,11 @@ function travis_make()
             echo "documentation failed."
             exit 1
         fi
+        ruby docs/generate.rb > /tmp/facts.md
+        if [ $? -ne 0 ]; then
+            echo "fact documentation failed."
+            exit 1
+        fi
         popd
     elif [ $1 != "cppcheck" ]; then
         LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so ctest -V 2>&1 | c++filt


### PR DESCRIPTION
Adding lib/docs/generate.rb (usage: ruby generate.rb > facts.md).
This script will transform the schema file into a markdown and extract
the name, purpose, resolutions, and caveats for each fact.