### PR TITLE
(CFACT-211) Query Ruby for correct library location

### DIFF
--- a/lib/inc/facter/execution/execution.hpp
+++ b/lib/inc/facter/execution/execution.hpp
@@ -183,7 +183,7 @@ namespace facter { namespace execution {
     /**
      * Executes the given program.
      * @param file The name or path of the program to execute.
-     * @param arguments The arguments to pass to the program.
+     * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param options The execution options.
      * @return Returns whether or not the execution succeeded paired with the child process output.
      */
@@ -195,7 +195,7 @@ namespace facter { namespace execution {
     /**
      * Executes the given program.
      * @param file The name or path of the program to execute.
-     * @param arguments The arguments to pass to the program.
+     * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param environment The environment variables to pass to the child process.
      * @param options The execution options.
      * @return Returns whether or not the execution succeeded paired with the child process output.
@@ -221,7 +221,7 @@ namespace facter { namespace execution {
     /**
      * Executes the given program and returns each line of output.
      * @param file The name or path of the program to execute.
-     * @param arguments The arguments to pass to the program.
+     * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param callback The callback that is called with each line of output.
      * @param options The execution options.
      * @return Returns true if the execution succeeded or false if it did not.
@@ -235,7 +235,7 @@ namespace facter { namespace execution {
     /**
      * Executes the given program and returns each line of output.
      * @param file The name or path of the program to execute.
-     * @param arguments The arguments to pass to the program.
+     * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param environment The environment variables to pass to the child process.
      * @param callback The callback that is called with each line of output.
      * @param options The execution options.

--- a/lib/inc/facter/ruby/api.hpp
+++ b/lib/inc/facter/ruby/api.hpp
@@ -615,6 +615,8 @@ namespace facter {  namespace ruby {
 
         static std::unique_ptr<api> create();
         static facter::util::dynamic_library find_library();
+        static facter::util::dynamic_library find_loaded_library();
+        static std::string libruby_configdir();
         static VALUE callback_thunk(VALUE parameter);
         static VALUE rescue_thunk(VALUE parameter, VALUE exception);
         static VALUE protect_thunk(VALUE parameter);

--- a/lib/src/facts/external/windows/powershell_resolver.cc
+++ b/lib/src/facts/external/windows/powershell_resolver.cc
@@ -49,7 +49,8 @@ namespace facter { namespace facts { namespace external {
                 }
             }
 
-            execution::each_line(pwrshell, {"-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -File ", "\"" + file + "\""},
+            execution::each_line(pwrshell, {"-NoProfile", "-NonInteractive", "-NoLogo", "-ExecutionPolicy", "Bypass",
+                                            "-File", file},
             [&facts](string const& line) {
                 auto pos = line.find('=');
                 if (pos == string::npos) {

--- a/lib/src/ruby/posix/api.cc
+++ b/lib/src/ruby/posix/api.cc
@@ -1,140 +1,18 @@
 #include <facter/ruby/api.hpp>
-#include <facter/execution/execution.hpp>
-#include <facter/util/directory.hpp>
-#include <facter/util/regex.hpp>
-#include <facter/util/environment.hpp>
-#include <leatherman/logging/logging.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace facter::util;
-using namespace facter::execution;
-using namespace boost::filesystem;
 
 namespace facter { namespace ruby {
 
-    dynamic_library api::find_library()
+    dynamic_library api::find_loaded_library()
     {
-        // First search for an already loaded Ruby
-        dynamic_library library = dynamic_library::find_by_symbol("ruby_init");
-        if (library.loaded()) {
-            return library;
-        }
+        return dynamic_library::find_by_symbol("ruby_init");
+    }
 
-#ifdef FACTER_RUBY
-        // Ruby lib location was specified at compile-time, fix to that.
-        if (!library.load(FACTER_RUBY)) {
-            LOG_WARNING("ruby library \"%1%\" could not be loaded.", FACTER_RUBY);
-        }
-        return library;
-#else
-        // Next try an environment variable
-        // This allows users to directly specify the ruby version to use
-        string value;
-        if (environment::get("FACTERRUBY", value)) {
-            if (library.load(value)) {
-                return library;
-            } else {
-                LOG_WARNING("ruby library \"%1%\" could not be loaded.", value);
-            }
-        }
-
-        // First try supporting rbenv
-        string ruby;
-        auto result = execution::execute("rbenv", { "which", "ruby" });
-        if (result.first) {
-            ruby = result.second;
-        }
-
-        if (ruby.empty()) {
-            // Next search the PATH
-            ruby = execution::which("ruby");
-            if (ruby.empty()) {
-                LOG_DEBUG("ruby could not be found on the PATH.");
-                return library;
-            }
-        }
-
-        LOG_DEBUG("ruby was found at \"%1%\".", ruby);
-
-        path parent_path = path(ruby).remove_filename() / "..";
-        path search_path;
-
-        boost::system::error_code ec;
-        if (sizeof(void*) == 8) {
-            // 64-bit build, check for lib64 first
-            path lib_path = parent_path / "lib64";
-            search_path = canonical(lib_path, ec);
-            if (ec) {
-                LOG_DEBUG("ruby library was not found at %1%: %2%.", lib_path, ec.message());
-            }
-        }
-
-        if (search_path.empty()) {
-            path lib_path = parent_path / "lib";
-            search_path = canonical(lib_path, ec);
-            if (ec) {
-                LOG_DEBUG("ruby library was not found at %1%: %2%.", lib_path, ec.message());
-                return library;
-            }
-        }
-
-        LOG_DEBUG("searching %1% for ruby libraries.", search_path);
-
-        int major = 0, minor = 0, patch = 0;
-        string libruby;
-
-        // Search the library directory for the "latest" libruby
-#if __APPLE__ && __MACH__
-        re_adapter regex("libruby(?:[-.](\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?\\.dylib$");
-#else
-        // Matches either libruby.so<version> or libruby-*.so<version>
-        re_adapter regex("libruby(?:-.*)?\\.so(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?$");
-#endif
-
-        directory::each_file(search_path.string(), [&](string const &file) {
-            // Ignore symlinks
-            if (is_symlink(file, ec)) {
-                return true;
-            }
-
-            // Ignore static libs, but notify the user
-            if (boost::ends_with(file, ".a")) {
-                LOG_DEBUG("ruby library \"%1%\" is not supported: ensure ruby was built with the --enable-shared configuration option.", file);
-                return true;
-            }
-
-            // Extract the version from the file name
-            int current_major = 0, current_minor = 0, current_patch = 0;
-            if (!re_search(file, regex, &current_major, &current_minor, &current_patch)) {
-                return true;
-            }
-
-            if (current_major == 1 && current_minor == 8) {
-                LOG_DEBUG("ruby library at \"%1%\" will be skipped: ruby 1.8 is not supported.", file);
-                return true;
-            }
-
-            // Check to see if the given version is greater than or equal to the current version
-            // This is done so that if all strings are empty (i.e. we've found only libruby.so),
-            // we set libruby to the file that was found.
-            if (tie(current_major, current_minor, current_patch) >= tie(major, minor, patch)) {
-                tie(major, minor, patch) = tie(current_major, current_minor, current_patch);
-                libruby = file;
-                LOG_DEBUG("found candidate ruby library \"%1%\".", file);
-            } else {
-                LOG_DEBUG("ruby library \"%1%\" has a higher version number than \"%2%\".", libruby, file);
-            }
-            return true;
-        }, "libruby.*\\.(?:so|dylib|a)");
-
-        // If we found a ruby, attempt to load it
-        if (!libruby.empty()) {
-            library.load(libruby);
-        }
-        return library;
-#endif
+    string api::libruby_configdir()
+    {
+        return "libdir";
     }
 
 }}  // namespace facter::ruby

--- a/lib/src/ruby/windows/api.cc
+++ b/lib/src/ruby/windows/api.cc
@@ -1,97 +1,19 @@
 #include <facter/ruby/api.hpp>
-#include <facter/execution/execution.hpp>
-#include <facter/util/directory.hpp>
-#include <facter/util/regex.hpp>
-#include <facter/util/environment.hpp>
-#include <leatherman/logging/logging.hpp>
-#include <boost/filesystem.hpp>
 
 using namespace std;
 using namespace facter::util;
-using namespace facter::execution;
-using namespace boost::filesystem;
 
 namespace facter { namespace ruby {
 
-    dynamic_library api::find_library()
+    dynamic_library api::find_loaded_library()
     {
         const string libruby_pattern = ".*ruby(\\d)?(\\d)?(\\d)?\\.dll";
-        // 1. Use dynamic_library::find_by_pattern to see if a DLL is already loaded
-        dynamic_library library = dynamic_library::find_by_pattern(libruby_pattern);
-        if (library.loaded()) {
-            return library;
-        }
+        return dynamic_library::find_by_pattern(libruby_pattern);
+    }
 
-#ifdef FACTER_RUBY
-        // Ruby lib location was specified at compile-time, fix to that.
-        if (!library.load(FACTER_RUBY)) {
-            LOG_WARNING("ruby library \"%1%\" could not be loaded.", FACTER_RUBY);
-        }
-        return library;
-#else
-
-        // 2. Check the FACTERRUBY environment variable
-        string value;
-        if (environment::get("FACTERRUBY", value)) {
-            if (library.load(value)) {
-                return library;
-            } else {
-                LOG_WARNING("ruby library %1% could not be loaded.", value);
-            }
-        }
-
-        // 3. Search the path for ruby.exe and look in the same directory for the ruby dll.
-        string ruby = execution::which("ruby");
-        if (!ruby.empty()) {
-            boost::system::error_code ec;
-            path libdir = canonical(path(ruby).remove_filename(), ec);
-            if (!ec) {
-                LOG_DEBUG("searching %1% for ruby libraries.", libdir);
-
-                // Search the library directory for the "latest" libruby
-                // Windows ruby builds use xxx for major/minor/patch versions, i.e. ruby193.dll
-                re_adapter regex(libruby_pattern);
-                int major = 0, minor = 0, patch = 0;
-                string libruby;
-                directory::each_file(libdir.string(), [&](string const& file) {
-                    // Ignore symlinks
-                    if (is_symlink(file, ec)) {
-                        return true;
-                    }
-
-                    // Extract the version from the file name
-                    int current_major = 0, current_minor = 0, current_patch = 0;
-                    if (!re_search(file, regex, &current_major, &current_minor, &current_patch)) {
-                        return true;
-                    }
-
-                    if (current_major == 1 && current_minor == 8) {
-                        LOG_DEBUG("ruby library at %1% will be skipped: ruby 1.8 is not supported.", file);
-                        return true;
-                    }
-
-                    // Use >= to allow for them to be empty; if no version numbers are matched the last lib is selected.
-                    if (tie(current_major, current_minor, current_patch) >= tie(major, minor, patch)) {
-                        tie(major, minor, patch) = tie(current_major, current_minor, current_patch);
-                        libruby = file;
-                        LOG_DEBUG("found candidate ruby library %1%.", file);
-                    } else {
-                        LOG_DEBUG("ruby library %1% has a higher version number than %2%.", libruby, file);
-                    }
-                    return true;
-                }, libruby_pattern);
-
-                if (!libruby.empty() && library.load(libruby)) {
-                    return library;
-                }
-            } else {
-              LOG_DEBUG("ruby library not found at %1%: %2%", path(ruby).remove_filename(), ec.message());
-            }
-        } else {
-            LOG_DEBUG("ruby could not be found on the PATH.");
-        }
-        return library;
-#endif
+    string api::libruby_configdir()
+    {
+        return "bindir";
     }
 
 }}  // namespace facter::ruby

--- a/lib/tests/fixtures/ruby/exec.rb
+++ b/lib/tests/fixtures/ruby/exec.rb
@@ -1,7 +1,7 @@
 Facter.add(:foo) do
     setcode do
-        result = Facter::Core::Execution.exec('echo bar')
-        raise 'nope' unless result == Facter::Util::Resolution.exec('echo bar')
+        result = Facter::Core::Execution.exec('echo bar baz')
+        raise 'nope' unless result == Facter::Util::Resolution.exec('echo bar baz')
         result
     end
 end

--- a/lib/tests/fixtures/ruby/simple_command.rb
+++ b/lib/tests/fixtures/ruby/simple_command.rb
@@ -1,5 +1,5 @@
 Facter.add(:foo) do
-    setcode 'echo bar'
+    setcode 'echo bar baz'
 end
 
 Facter.add(:foo) do

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -150,7 +150,7 @@ SCENARIO("custom facts written in Ruby") {
     GIVEN("a fact with a command") {
         REQUIRE(load_custom_fact("simple_command.rb", facts));
         THEN("the value should be in the collection") {
-            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar baz\"");
         }
     }
     GIVEN("a fact with a bad command") {
@@ -518,7 +518,7 @@ SCENARIO("custom facts written in Ruby") {
     GIVEN("a fact resolution that uses Facter::Core::Execution#exec") {
         REQUIRE(load_custom_fact("exec.rb", facts));
         THEN("value should be in the collection") {
-            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar baz\"");
         }
     }
     GIVEN("a fact that uses timeout") {


### PR DESCRIPTION
Without this change, lookup for libruby would search based on the
location of Ruby found on PATH. This required special handling for
wrappers like rbenv.

Change lookup to query Ruby's RbConfig for the location of its dynamic
library instead of searching the filesystem.

Also rewrite the execute functions' argument handling for Windows. Without
this change arguments that needed to be quoted due to spaces didn't work.
Automatically quotes arguments as needed for consistency with the POSIX
behavior, requiring that separate arguments are passed as separate strings.