### PR TITLE
(CFACT-233) Allow regexps and ranges for custom fact confine values

### DIFF
--- a/lib/inc/facter/ruby/api.hpp
+++ b/lib/inc/facter/ruby/api.hpp
@@ -560,6 +560,14 @@ namespace facter {  namespace ruby {
         bool equals(VALUE first, VALUE second) const;
 
         /**
+         * Determines if the first value has case equality (===) with the second value.
+         * @param first The first value to compare.
+         * @param second The second value to compare.
+         * @return Returns true if === returns true for the first and second values.
+         */
+        bool case_equals(VALUE first, VALUE second) const;
+
+        /**
          * Gets the underlying native instance from a Ruby data object.
          * The Ruby object must have been allocated with rb_data_object_alloc.
          * @tparam T The underlying native type.

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -437,4 +437,9 @@ namespace facter { namespace ruby {
         return is_true(rb_funcall(first, rb_intern("eql?"), 1, second));
     }
 
+    bool api::case_equals(VALUE first, VALUE second) const
+    {
+        return is_true(rb_funcall(first, rb_intern("==="), 1, second));
+    }
+
 }}  // namespace facter::ruby

--- a/lib/src/ruby/confine.cc
+++ b/lib/src/ruby/confine.cc
@@ -53,7 +53,7 @@ namespace facter { namespace ruby {
                 return found;
             }
             // Compare the value directly
-            return ruby.equals(facter.normalize(_expected), value);
+            return ruby.case_equals(facter.normalize(_expected), value);
         }
         // If we have only a block, execute it
         if (!ruby.is_nil(_block)) {

--- a/lib/src/ruby/resolution.cc
+++ b/lib/src/ruby/resolution.cc
@@ -122,7 +122,6 @@ namespace facter { namespace ruby {
                 if (ruby.rb_block_given_p()) {
                     ruby.rb_raise(*ruby.rb_eArgError, "a block is unexpected when passing a Hash");
                 }
-                // Populate the above map based on the hash's contents
                 ruby.hash_for_each(confines, [&](VALUE key, VALUE value) {
                     if (ruby.is_symbol(key)) {
                         key = ruby.rb_sym_to_s(key);
@@ -133,17 +132,6 @@ namespace facter { namespace ruby {
                     if (ruby.is_symbol(value)) {
                         value = ruby.rb_sym_to_s(value);
                     }
-                    if (ruby.is_array(value)) {
-                        ruby.array_for_each(value, [&](VALUE value) {
-                            if (!ruby.is_string(value) && !ruby.is_symbol(value)) {
-                                ruby.rb_raise(*ruby.rb_eTypeError, "expected only Symbol or String for confine array elements");
-                            }
-                            return true;
-                        });
-                    } else if (!ruby.is_true(value) && !ruby.is_false(value) &&!ruby.is_string(value)) {
-                        ruby.rb_raise(*ruby.rb_eTypeError, "expected true, false, Symbol, String, or Array of String/Symbol for confine value");
-                    }
-
                     _confines.emplace_back(ruby::confine(key, value, ruby.nil_value()));
                     return true;
                 });

--- a/lib/tests/fixtures/ruby/range_confine.rb
+++ b/lib/tests/fixtures/ruby/range_confine.rb
@@ -1,0 +1,6 @@
+Facter.add(:foo) do
+    confine :fact => (3..5)
+    setcode do
+        'bar'
+    end
+end

--- a/lib/tests/fixtures/ruby/regexp_confine.rb
+++ b/lib/tests/fixtures/ruby/regexp_confine.rb
@@ -1,0 +1,6 @@
+Facter.add(:foo) do
+    confine :fact => /foo/
+    setcode do
+        'bar'
+    end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -245,6 +245,34 @@ SCENARIO("custom facts written in Ruby") {
                 REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
             }
         }
+        WHEN("the confine is a regular expression that evaluates to true") {
+            facts.add("fact", make_value<string_value>("foo"));
+            REQUIRE(load_custom_fact("regexp_confine.rb", facts));
+            THEN("the value should be in the collection") {
+              REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+            }
+        }
+        WHEN("the confine is a regular expression that evaluates to false") {
+            facts.add("fact", make_value<string_value>("baz"));
+            REQUIRE(load_custom_fact("regexp_confine.rb", facts));
+            THEN("the value should not be in the collection") {
+              REQUIRE_FALSE(facts["foo"]);
+            }
+        }
+        WHEN("the confine is a range that evaluates to true") {
+            facts.add("fact", make_value<integer_value>(4));
+            REQUIRE(load_custom_fact("range_confine.rb", facts));
+            THEN("the value should be in the collection") {
+              REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+            }
+        }
+        WHEN("the confine is a range that evaluates to false") {
+            facts.add("fact", make_value<integer_value>(10));
+            REQUIRE(load_custom_fact("range_confine.rb", facts));
+            THEN("the value should not be in the collection") {
+              REQUIRE_FALSE(facts["foo"]);
+            }
+        }
         WHEN("the confine evaluates to true") {
             facts.add("fact", make_value<boolean_value>(true));
             REQUIRE(load_custom_fact("boolean_true_confine.rb", facts));


### PR DESCRIPTION
In previous versions of Facter, confine values for facts could utilize
regular expressions and ranges. Currently, native Facter only allows
true, false, Symbols, Strings, and Arrays of Strings/Symbols for
custom facts.

This commit updates native Facter to allow regular expressions and
ranges in confine statements in order to preserve backwards
compatibility with older versions of Facter.