### PR TITLE
(CFACT-83) Stop excluding all symbols from libfacter on Linux.

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(
 )
 
 add_executable(cfacter ${CFACTER_SOURCES})
-target_link_libraries(cfacter libfacter ${Boost_LIBRARIES} ${LEATHERMAN_NOWIDE_LIB})
+target_link_libraries(cfacter libfacter ${Boost_PROGRAM_OPTIONS_LIBRARY} ${LEATHERMAN_NOWIDE_LIB})
 set_target_properties(cfacter PROPERTIES COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY" COTIRE_ENABLE_PRECOMPILED_HEADER ${PRECOMPILED_HEADERS})
 cotire(cfacter)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -241,7 +241,7 @@ add_library(libfacter SHARED $<TARGET_OBJECTS:libfactersrc>)
 set_target_properties(libfacter PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a" VERSION "${LIBFACTER_VERSION_MAJOR}.${LIBFACTER_VERSION_MINOR}.${LIBFACTER_VERSION_PATCH}" COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY" COTIRE_ENABLE_PRECOMPILED_HEADER ${PRECOMPILED_HEADERS})
 
 # Link in additional libraries
-target_link_libraries(libfacter
+target_link_libraries(libfacter PRIVATE
     ${POSIX_LIBRARIES}
     ${LIBFACTER_PLATFORM_LIBRARIES}
     ${LEATHERMAN_LIBRARIES}
@@ -257,7 +257,6 @@ generate_export_header(libfacter EXPORT_FILE_NAME "${CMAKE_CURRENT_LIST_DIR}/inc
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     add_compiler_export_flags()
-    set_target_properties(libfacter PROPERTIES LINK_FLAGS "-Wl,--exclude-libs=ALL")
 elseif (WIN32)
     add_compiler_export_flags()
     add_definitions("-Dlibfacter_EXPORTS")


### PR DESCRIPTION
Removing --exclude-libs=ALL on Linux because this prevents libstdc++
from working when statically linked.

This also prevents all of libfacter's dependencies from getting passed
to the linker when linking cfacter.