### PR TITLE
(CFACT-83) Make facter::execution::process_stream internal.

### DIFF
--- a/lib/inc/facter/execution/execution.hpp
+++ b/lib/inc/facter/execution/execution.hpp
@@ -242,18 +242,4 @@ namespace facter { namespace execution {
         std::function<bool(std::string&)> callback,
         facter::util::option_set<execution_options> const& options = { execution_options::defaults });
 
-    /**
-     * Reads from a stream closure until there is no more data to read.
-     * If a callback is supplied, buffers each line and passes it to the callback.
-     * Otherwise, returns the concatenation of the stream.
-     * @param yield_input The input stream closure; it expects a mutable string buffer, and returns whether the closure should be invoked again for more input.
-     * @param callback The callback that is called with each line of output.
-     * @param options The execution options.
-     * @return Returns the stream results concatenated together, or an empty string if callback is not null.
-     */
-    std::string LIBFACTER_EXPORT process_stream(
-        std::function<bool(std::string&)> yield_input,
-        std::function<bool(std::string&)> callback,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
-
 }}  // namespace facter::execution

--- a/lib/inc/internal/execution/execution.hpp
+++ b/lib/inc/internal/execution/execution.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * Declares functions used for executing commands.
+ */
+#pragma once
+
+#include <string>
+#include <functional>
+#include <facter/execution/execution.hpp>
+#include <facter/util/option_set.hpp>
+
+namespace facter { namespace execution {
+
+    /**
+     * Reads from a stream closure until there is no more data to read.
+     * If a callback is supplied, buffers each line and passes it to the callback.
+     * Otherwise, returns the concatenation of the stream.
+     * @param yield_input The input stream closure; it expects a mutable string buffer, and returns whether the closure should be invoked again for more input.
+     * @param callback The callback that is called with each line of output.
+     * @param options The execution options.
+     * @return Returns the stream results concatenated together, or an empty string if callback is not null.
+     */
+    std::string process_stream(
+        std::function<bool(std::string&)> yield_input,
+        std::function<bool(std::string&)> callback,
+        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+
+}}  // namespace facter::execution

--- a/lib/src/execution/posix/execution.cc
+++ b/lib/src/execution/posix/execution.cc
@@ -1,5 +1,5 @@
-#include <facter/execution/execution.hpp>
 #include <facter/util/directory.hpp>
+#include <internal/execution/execution.hpp>
 #include <internal/util/posix/scoped_descriptor.hpp>
 #include <internal/ruby/api.hpp>
 #include <leatherman/logging/logging.hpp>

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -1,7 +1,7 @@
-#include <facter/execution/execution.hpp>
 #include <facter/util/directory.hpp>
 #include <facter/util/environment.hpp>
 #include <facter/util/scoped_resource.hpp>
+#include <internal/execution/execution.hpp>
 #include <internal/util/scoped_env.hpp>
 #include <internal/util/windows/system_error.hpp>
 #include <internal/util/windows/windows.hpp>


### PR DESCRIPTION
The facter::execution::process_stream function is meant to be an
internal function used by other functions in the execution namespace,
but it was included in the public header (and therefore exported).

This commit moves it to an "internal" header.