### PR TITLE
(CFACT-253) Implement timeout option for command execution.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -74,6 +74,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/util/dynamic_library.cc"
     "src/util/environment.cc"
     "src/util/file.cc"
+    "src/util/scope_exit.cc"
     "src/util/scoped_env.cc"
     "src/util/scoped_file.cc"
     "src/util/string.cc"

--- a/lib/inc/facter/execution/execution.hpp
+++ b/lib/inc/facter/execution/execution.hpp
@@ -149,6 +149,18 @@ namespace facter { namespace execution {
     };
 
     /**
+     * Exception that is thrown when a command times out.
+     */
+    struct LIBFACTER_EXPORT timeout_exception : execution_exception
+    {
+        /**
+         * Constructs a timeout_exception.
+         * @param message The exception message.
+         */
+        explicit timeout_exception(std::string const& message);
+    };
+
+    /**
      * Searches the given paths for the given executable file.
      * @param file The file to search for.
      * @param directories The directories to search.
@@ -168,23 +180,27 @@ namespace facter { namespace execution {
      * Executes the given program.
      * @param file The name or path of the program to execute.
      * @param options The execution options.
+     * @param timeout The timeout, in seconds.  Defaults to no timeout.
      * @return Returns whether or not the execution succeeded paired with the child process output.
      */
     std::pair<bool, std::string> LIBFACTER_EXPORT execute(
         std::string const& file,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+        facter::util::option_set<execution_options> const& options = { execution_options::defaults },
+        uint32_t timeout = 0);
 
     /**
      * Executes the given program.
      * @param file The name or path of the program to execute.
      * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param options The execution options.
+     * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @return Returns whether or not the execution succeeded paired with the child process output.
      */
     std::pair<bool, std::string> LIBFACTER_EXPORT execute(
         std::string const& file,
         std::vector<std::string> const& arguments,
-        facter::util::option_set<execution_options> const& options  = { execution_options::defaults });
+        facter::util::option_set<execution_options> const& options  = { execution_options::defaults },
+        uint32_t timeout = 0);
 
     /**
      * Executes the given program.
@@ -192,25 +208,29 @@ namespace facter { namespace execution {
      * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param environment The environment variables to pass to the child process.
      * @param options The execution options.
+     * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @return Returns whether or not the execution succeeded paired with the child process output.
      */
     std::pair<bool, std::string> LIBFACTER_EXPORT execute(
         std::string const& file,
         std::vector<std::string> const& arguments,
         std::map<std::string, std::string> const& environment,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+        facter::util::option_set<execution_options> const& options = { execution_options::defaults },
+        uint32_t timeout = 0);
 
     /**
      * Executes the given program and returns each line of output.
      * @param file The name or path of the program to execute.
      * @param callback The callback that is called with each line of output.
      * @param options The execution options.
+     * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @return Returns true if the execution succeeded or false if it did not.
      */
     bool LIBFACTER_EXPORT each_line(
         std::string const& file,
         std::function<bool(std::string&)> callback,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+        facter::util::option_set<execution_options> const& options = { execution_options::defaults },
+        uint32_t timeout = 0);
 
     /**
      * Executes the given program and returns each line of output.
@@ -218,13 +238,15 @@ namespace facter { namespace execution {
      * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param callback The callback that is called with each line of output.
      * @param options The execution options.
+     * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @return Returns true if the execution succeeded or false if it did not.
      */
     bool LIBFACTER_EXPORT each_line(
         std::string const& file,
         std::vector<std::string> const& arguments,
         std::function<bool(std::string&)> callback,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+        facter::util::option_set<execution_options> const& options = { execution_options::defaults },
+        uint32_t timeout = 0);
 
     /**
      * Executes the given program and returns each line of output.
@@ -233,6 +255,7 @@ namespace facter { namespace execution {
      * @param environment The environment variables to pass to the child process.
      * @param callback The callback that is called with each line of output.
      * @param options The execution options.
+     * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @return Returns true if the execution succeeded or false if it did not.
      */
     bool LIBFACTER_EXPORT each_line(
@@ -240,6 +263,7 @@ namespace facter { namespace execution {
         std::vector<std::string> const& arguments,
         std::map<std::string, std::string> const& environment,
         std::function<bool(std::string&)> callback,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+        facter::util::option_set<execution_options> const& options = { execution_options::defaults },
+        uint32_t timeout = 0);
 
 }}  // namespace facter::execution

--- a/lib/inc/facter/util/scope_exit.hpp
+++ b/lib/inc/facter/util/scope_exit.hpp
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * Declares the base class for scope exit.
+ */
+#pragma once
+
+#include <functional>
+#include "../export.h"
+
+namespace facter { namespace util {
+
+    /**
+     * Used to call a function when scope is exited.
+    */
+    struct LIBFACTER_EXPORT scope_exit
+    {
+        /**
+         * Constructs a scope_exit.
+         */
+        scope_exit();
+
+        /**
+         * Constructs a scope_exit.
+         * @param callback The function to call when scope is exited.
+         */
+        explicit scope_exit(std::function<void()> callback);
+
+        /**
+         * Moves the given scope_exit into this scope_exit.
+         * @param other The scope_exit to move into this scope_exit.
+         */
+        scope_exit(scope_exit&& other);
+
+        /**
+         * Moves the given scoped_resource into this scoped_resource.
+         * @param other The scoped_resource to move into this scoped_resource.
+         * @return Returns this scope_exit.
+         */
+        scope_exit& operator=(scope_exit&& other);
+
+        /**
+         * Destructs a scope_exit.
+         */
+        ~scope_exit();
+
+        /**
+         * Invokes the callback.
+         * If called, the callback will not be called upon destruction.
+         */
+        void invoke();
+
+    private:
+        explicit scope_exit(scope_exit const&) = delete;
+        scope_exit& operator=(scope_exit const&) = delete;
+        void* operator new(size_t) = delete;
+        void operator delete(void*) = delete;
+        void* operator new[](size_t) = delete;
+        void operator delete[](void* ptr) = delete;
+
+        std::function<void()> _callback;
+    };
+
+}}  // namespace facter::util

--- a/lib/inc/facter/util/scoped_resource.hpp
+++ b/lib/inc/facter/util/scoped_resource.hpp
@@ -65,6 +65,9 @@ namespace facter { namespace util {
             release();
             _resource = std::move(other._resource);
             _deleter = std::move(other._deleter);
+
+            // Ensure the deleter is in a known "empty" state; we can't rely on default move semantics for that
+            other._deleter = nullptr;
             return *this;
         }
 

--- a/lib/inc/facter/util/scoped_resource.hpp
+++ b/lib/inc/facter/util/scoped_resource.hpp
@@ -21,7 +21,9 @@ namespace facter { namespace util {
          * Constructs an uninitialized scoped_resource.
          * Can be initialized via move assignment.
          */
-        scoped_resource() : _deleter(nullptr)
+        scoped_resource() :
+            _resource(),
+            _deleter(nullptr)
         {
         }
 

--- a/lib/inc/internal/execution/execution.hpp
+++ b/lib/inc/internal/execution/execution.hpp
@@ -6,8 +6,6 @@
 
 #include <string>
 #include <functional>
-#include <facter/execution/execution.hpp>
-#include <facter/util/option_set.hpp>
 
 namespace facter { namespace execution {
 
@@ -15,14 +13,11 @@ namespace facter { namespace execution {
      * Reads from a stream closure until there is no more data to read.
      * If a callback is supplied, buffers each line and passes it to the callback.
      * Otherwise, returns the concatenation of the stream.
-     * @param yield_input The input stream closure; it expects a mutable string buffer, and returns whether the closure should be invoked again for more input.
+     * @param trim_output True if output should be trimmed or false if not.
      * @param callback The callback that is called with each line of output.
-     * @param options The execution options.
+     * @param yield_input The input stream closure; it expects a mutable string buffer, and returns whether the closure should be invoked again for more input.
      * @return Returns the stream results concatenated together, or an empty string if callback is not null.
      */
-    std::string process_stream(
-        std::function<bool(std::string&)> yield_input,
-        std::function<bool(std::string&)> callback,
-        facter::util::option_set<execution_options> const& options = { execution_options::defaults });
+    std::string process_stream(bool trim_output, std::function<bool(std::string&)> callback, std::function<bool(std::string&)> yield_input);
 
 }}  // namespace facter::execution

--- a/lib/src/util/scope_exit.cc
+++ b/lib/src/util/scope_exit.cc
@@ -1,0 +1,43 @@
+#include <facter/util/scope_exit.hpp>
+
+using namespace std;
+
+namespace facter { namespace util {
+
+    scope_exit::scope_exit()
+    {
+    }
+
+    scope_exit::scope_exit(function<void()> callback) :
+        _callback(callback)
+    {
+    }
+
+    scope_exit::scope_exit(scope_exit&& other)
+    {
+        *this = std::move(other);
+    }
+
+    scope_exit& scope_exit::operator=(scope_exit&& other)
+    {
+        _callback = std::move(other._callback);
+
+        // Ensure the callback is in a known "empty" state; we can't rely on default move semantics for that
+        other._callback = nullptr;
+        return *this;
+    }
+
+    scope_exit::~scope_exit()
+    {
+        invoke();
+    }
+
+    void scope_exit::invoke()
+    {
+        if (_callback) {
+            _callback();
+            _callback = nullptr;
+        }
+    }
+
+}}  // namespace facter::util

--- a/lib/tests/execution/posix/execution.cc
+++ b/lib/tests/execution/posix/execution.cc
@@ -227,6 +227,14 @@ SCENARIO("executing commands with execution::execute") {
             }
         }
     }
+    GIVEN("a long-running command") {
+        WHEN("given a timeout") {
+            THEN("a timeout exception should be thrown") {
+                option_set<execution_options> options = { execution_options::defaults };
+                REQUIRE_THROWS_AS(execute("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/sleep.sh" }, options, 1), timeout_exception);
+            }
+        }
+    }
 }
 
 SCENARIO("executing commands with execution::each_line") {
@@ -364,6 +372,14 @@ SCENARIO("executing commands with execution::each_line") {
         WHEN("the 'throw on signal' option is used") {
             THEN("a child signal exception is thrown") {
                 REQUIRE_THROWS_AS(each_line("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/selfkill.sh" }, [](string& line) { return true; }, option_set<execution_options>({ execution_options::defaults, execution_options::throw_on_signal })), child_signal_exception);
+            }
+        }
+    }
+    GIVEN("a long-running command") {
+        WHEN("given a timeout") {
+            THEN("a timeout exception should be thrown") {
+                option_set<execution_options> options = { execution_options::defaults };
+                REQUIRE_THROWS_AS(each_line("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/sleep.sh" }, [](string& line) { return true; }, options, 1), timeout_exception);
             }
         }
     }

--- a/lib/tests/execution/windows/execution.cc
+++ b/lib/tests/execution/windows/execution.cc
@@ -185,6 +185,19 @@ SCENARIO("executing commands with execution::execute") {
             }
         }
     }
+    GIVEN("a long-running command") {
+        WHEN("given a timeout") {
+            THEN("a timeout exception should be thrown") {
+                string ruby = which("ruby.exe");
+                if (ruby.empty()) {
+                    WARN("skipping command timeout test because no ruby was found on the PATH.");
+                    return;
+                }
+                option_set<execution_options> options = { execution_options::defaults };
+                REQUIRE_THROWS_AS(execute("ruby.exe", { "-e", "sleep 15" }, options, 1), timeout_exception);
+            }
+        }
+    }
 }
 
 SCENARIO("executing commands with execution::each_line") {
@@ -316,6 +329,19 @@ SCENARIO("executing commands with execution::each_line") {
         WHEN("the 'throw on non-zero exit' option is used") {
             THEN("a child exit exception is thrown") {
                 REQUIRE_THROWS_AS(each_line("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, [](string& line) { return true; }, option_set<execution_options>({execution_options::defaults, execution_options::throw_on_nonzero_exit})), child_exit_exception);
+            }
+        }
+    }
+    GIVEN("a long-running command") {
+        WHEN("given a timeout") {
+            THEN("a timeout exception should be thrown") {
+                string ruby = which("ruby.exe");
+                if (ruby.empty()) {
+                    WARN("skipping command timeout test because no ruby was found on the PATH.");
+                    return;
+                }
+                option_set<execution_options> options = { execution_options::defaults };
+                REQUIRE_THROWS_AS(each_line("ruby.exe", { "-e", "sleep 15" }, [&](string&) { return true; }, options, 1), timeout_exception);
             }
         }
     }

--- a/lib/tests/fixtures/execution/sleep.sh
+++ b/lib/tests/fixtures/execution/sleep.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+sleep 60


### PR DESCRIPTION
Implementing a timeout for command execution on Windows and POSIX operating systems.

This feature will enable us to timeout command executions that are known to hang Facter (such as `prtdiag` on Solaris).