### PR TITLE
(maint) Update cppcheck to 1.68

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_install:
   # grab a pre-built cppcheck from s3
   - wget https://s3.amazonaws.com/kylo-pl-bucket/pcre-8.36_install.tar.bz2
   - sudo tar xjvf pcre-8.36_install.tar.bz2 --strip 1 -C /usr/local
-  - wget https://s3.amazonaws.com/kylo-pl-bucket/cppcheck-1.67_install.tar.bz2
-  - sudo tar xjvf cppcheck-1.67_install.tar.bz2 --strip 1 -C /usr/local
+  - wget https://s3.amazonaws.com/kylo-pl-bucket/cppcheck-1.68_install.tar.bz2
+  - sudo tar xjvf cppcheck-1.68_install.tar.bz2 --strip 1 -C /usr/local
   # grab a pre-built doxygen 1.8.7 from s3
   - wget https://s3.amazonaws.com/kylo-pl-bucket/doxygen_install.tar.bz2
   - sudo tar xjvf doxygen_install.tar.bz2 --strip 1 -C /usr/local

--- a/contrib/dockerfiles/travis-cpp-builder/Dockerfile
+++ b/contrib/dockerfiles/travis-cpp-builder/Dockerfile
@@ -40,17 +40,17 @@ RUN wget https://github.com/doxygen/doxygen/archive/Release_1_8_7.tar.gz -O doxy
     rm -r doxygen-1.8.7.tgz doxygen-Release_1_8_7
 
 # Build and install cppcheck
-RUN wget http://sourceforge.net/projects/pcre/files/pcre/8.36/pcre-8.36.tar.bz2/download -O pcre-8.36.tar.bz2 && \
+RUN wget http://sourceforge.net/projects/pcre/files/pcre/8.36/pcre-8.36.tar.bz2 -O pcre-8.36.tar.bz2 && \
     tar xjf pcre-8.36.tar.bz2 && \
     cd pcre-8.36 && \
     ./configure > /dev/null && \
     make install > /dev/null && \
     cd .. && \
     rm -r pcre-8.36.tar.bz2 pcre-8.36
-RUN wget http://sourceforge.net/projects/cppcheck/files/cppcheck/1.67/cppcheck-1.67.tar.bz2/download -O cppcheck-1.67.tar.bz2 && \
-    tar xjf cppcheck-1.67.tar.bz2 && \
-    cd cppcheck-1.67 && \
+RUN wget http://sourceforge.net/projects/cppcheck/files/cppcheck/1.68/cppcheck-1.68.tar.bz2 -O cppcheck-1.68.tar.bz2 && \
+    tar xjf cppcheck-1.68.tar.bz2 && \
+    cd cppcheck-1.68 && \
     make install SRCDIR=build CFGDIR=/usr/local/cfg HAVE_RULES=yes > /dev/null && \
     cd .. && \
-    rm -r cppcheck-1.67.tar.bz2 cppcheck-1.67
+    rm -r cppcheck-1.68.tar.bz2 cppcheck-1.68
 


### PR DESCRIPTION
Updates the Dockerfile used to configure a Travis-equivalent builder to
build cppcheck 1.68. That version of cppcheck fixes errors with unused
return values in variadic templates.

Without this change, we run into false errors in cppcheck about unused
return values when they're passed to variadic templates. cppcheck 1.68
fixes that issue.