### PR TITLE
(maint) Reduce build procs to avoid out-of-memory

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -5,12 +5,13 @@ export VERBOSE=1
 
 PREFIX      :=/usr
 BUILDPREFIX :=/opt/pl-build-tools
-NPROC       :=$(shell nproc)
 CPPFLAGS    :=$(shell dpkg-buildflags --get CPPFLAGS)
 CFLAGS      :=$(shell dpkg-buildflags --get CFLAGS)
 CXXFLAGS    :=$(shell dpkg-buildflags --get CXXFLAGS)
 LDFLAGS     :=$(shell dpkg-buildflags --get LDFLAGS)
-NUMPROC     :=$(shell expr $$(nproc) + 1)
+
+# Hard-coded to 2. Our deb builders have a hard-limit at 4GB of memory.
+NUMPROC     :=2
 
 export CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
 


### PR DESCRIPTION
Debian build VMs are occasionally running out of memory with the message
`virtual memory exhausted: Cannot allocate memory`. This is likely
because compiling C++ is a memory hog, and machines don't have enough
memory allocated to cover a build for each core.

Hard-code the number of parallel procs to 2. Most of our debian builders
use 4GB of memory, and more than 2 processes are likely to exhaust that
at some point.