### PR TITLE
(CFACT-263) Fix child process cleanup for POSIX command timeout.

### DIFF
--- a/lib/inc/facter/execution/execution.hpp
+++ b/lib/inc/facter/execution/execution.hpp
@@ -156,8 +156,18 @@ namespace facter { namespace execution {
         /**
          * Constructs a timeout_exception.
          * @param message The exception message.
+         * @param pid The process id of the process that timed out and was killed.
          */
-        explicit timeout_exception(std::string const& message);
+        timeout_exception(std::string const& message, size_t pid);
+
+        /**
+         * Gets the process id of the process that timed out and was killed.
+         * @return Returns the process id of the process that timed out and was killed.
+         */
+        size_t pid() const;
+
+     private:
+        size_t _pid;
     };
 
     /**

--- a/lib/src/execution/execution.cc
+++ b/lib/src/execution/execution.cc
@@ -54,9 +54,15 @@ namespace facter { namespace execution {
         return _signal;
     }
 
-    timeout_exception::timeout_exception(string const& message) :
-        execution_exception(message)
+    timeout_exception::timeout_exception(string const& message, size_t pid) :
+        execution_exception(message),
+        _pid(pid)
     {
+    }
+
+    size_t timeout_exception::pid() const
+    {
+        return _pid;
     }
 
     void log_execution(string const& file, vector<string> const* arguments)

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -365,7 +365,7 @@ namespace facter { namespace execution {
             // Before doing anything, check to see if there's been a timeout
             // This is done pre-emptively in case ReadFile never returns ERROR_IO_PENDING
             if (timer && WaitForSingleObject(timer, 0) == WAIT_OBJECT_0) {
-                throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str());
+                throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str(), static_cast<size_t>(procInfo.dwProcessId));
             }
 
             // Read the output pipe
@@ -398,7 +398,7 @@ namespace facter { namespace execution {
             }
             if (result == WAIT_OBJECT_0 + 1) {
                 // The timer has expired
-                throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str());
+                throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str(), static_cast<size_t>(procInfo.dwProcessId));
             }
             LOG_ERROR("failed to wait for child process output: %1%.", system_error());
             throw execution_exception("failed to wait for child process output.");
@@ -413,7 +413,7 @@ namespace facter { namespace execution {
             terminate = false;
         } else if (wait_result == WAIT_OBJECT_0 + 1) {
             // Timeout while waiting on the process to complete
-            throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str());
+            throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str(), static_cast<size_t>(procInfo.dwProcessId));
         } else {
             LOG_ERROR("failed to wait for child process to terminate: %1%.", system_error());
             throw execution_exception("failed to wait for child process to terminate.");


### PR DESCRIPTION
Fixing POSIX command timeout to properly kill the entire child process
tree rather than just the child.  This will kill other processes spawned
from the child process.