### PR TITLE
(maint) Fix submodule init and failure mode in Windows packaging

### DIFF
--- a/contrib/cfacter.ps1
+++ b/contrib/cfacter.ps1
@@ -10,6 +10,8 @@ param (
 [string] $cfacterFork='git://github.com/puppetlabs/cfacter'
 )
 
+$ErrorActionPreference = 'Stop'
+
 # Ensure TEMP directory is set and exists. Git.install can fail otherwise.
 try {
     if (!(Test-Path $env:TEMP)) { throw }
@@ -95,9 +97,10 @@ echo $env:PATH
 cd $sourceDir
 
 ## Download cfacter and setup build directories
-git clone --recursive $cfacterFork cfacter
+git clone $cfacterFork cfacter
 cd cfacter
 git checkout $cfacterRef
+git submodule update --init --recursive
 mkdir -Force release
 cd release
 $buildDir=$pwd


### PR DESCRIPTION
Without this change, packaging on Windows initializes the submodules on
the master branch, no matter what ref is requested.

Do submodule init and update after changing to the requested branch, to
ensure the correct submodules are initialized and at the right ref.

We are currently running into some errors where building native facter
will throw errors, but the script will continue to run. This isn't good,
especially because it means we ship an incomplete archive. This commit
is an attempt at having the native facter build script fail in a
consistent way when things go wrong.